### PR TITLE
[FEAT] 관리자 메인페이지에서 직원 목록을 10개만 불러옵니다.

### DIFF
--- a/src/components/admin/user-list/UserList.css
+++ b/src/components/admin/user-list/UserList.css
@@ -1,0 +1,66 @@
+.member-section {
+  background: var(--color-pale-gray);
+  border-radius: var(--space-small);
+  padding: 20px;
+}
+
+.member-list {
+  background: var(--color-white);
+  border-radius: var(--space-small);
+}
+
+.member-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.member-item {
+  display: flex;
+  align-items: center;
+  padding: 14px;
+  border-bottom: 1px solid #eee;
+  gap: var(--space-medium);
+}
+
+.status-dot {
+  margin-left: var(--space-medium);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #ccc;
+}
+
+.status-dot.active {
+  background-color: var(--color-green);
+  box-shadow:
+    0 0 4px 2px rgba(76, 175, 80, 0.4),
+    0 0 8px 4px rgba(76, 175, 80, 0.2);
+  filter: blur(1px);
+  animation: glow 2s ease-in-out infinite;
+}
+
+.member-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: var(--color-pale-gray);
+}
+
+.member-info {
+  flex: 1;
+  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--space-small);
+}
+
+.detail-btn {
+  padding: 8px 16px;
+  border-radius: var(--space-small);
+  cursor: pointer;
+}
+
+.detail-btn:hover {
+  transition: background-color 0.3s;
+}

--- a/src/components/admin/user-list/UserList.css
+++ b/src/components/admin/user-list/UserList.css
@@ -1,12 +1,14 @@
 .member-section {
   background: var(--color-pale-gray);
-  border-radius: var(--space-small);
+  border-radius: 10px;
   padding: 20px;
 }
 
 .member-list {
   background: var(--color-white);
-  border-radius: var(--space-small);
+  border-radius: 10px;
+  overflow-y: scroll;
+  max-height: 400px;
 }
 
 .member-grid {
@@ -45,22 +47,42 @@
   height: 40px;
   border-radius: 50%;
   background-color: var(--color-pale-gray);
+  object-fit: cover;
 }
 
 .member-info {
   flex: 1;
   align-items: center;
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: 60px 60px 80px 100px 220px 150px;
   gap: var(--space-small);
+}
+
+.member-info span {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 0 var(--space-small);
 }
 
 .detail-btn {
   padding: 8px 16px;
   border-radius: var(--space-small);
   cursor: pointer;
+  width: 200px;
 }
 
 .detail-btn:hover {
   transition: background-color 0.3s;
+}
+
+.loading {
+  text-align: center;
+  padding: 20px;
+  color: #6c6c6c;
+}
+
+.error {
+  text-align: center;
+  padding: 20px;
+  color: #f44336;
 }

--- a/src/components/admin/user-list/UserList.js
+++ b/src/components/admin/user-list/UserList.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import './UserList.css';
 
-export const RenderUserList = async container => {
+export const RenderUserList = async (container, filter = 'all') => {
   container.innerHTML =
     '<div class="loading">직원 정보를 가져오는 중입니다.</div>';
 
@@ -9,7 +9,22 @@ export const RenderUserList = async container => {
     const response = await axios.get('../../../../server/data/users.json');
     const users = response.data;
 
-    const displayUsers = users.slice(0, 10);
+    // 필터링
+    const filteredUsers =
+      filter === 'all'
+        ? users
+        : users.filter(user => {
+            switch (filter) {
+              case 'student':
+                return user.user_position === '수강생';
+              case 'manager':
+                return user.user_position === '매니저';
+              default:
+                return true;
+            }
+          });
+
+    const displayUsers = filteredUsers.slice(0, 10);
 
     container.innerHTML = `
       <section class="member-section">

--- a/src/components/admin/user-list/UserList.js
+++ b/src/components/admin/user-list/UserList.js
@@ -1,0 +1,23 @@
+import './UserList.css';
+
+export const RenderUserList = container => {
+  container.innerHTML = `
+    <section class="member-section">
+      <div class="member-list">
+        <ul class="member-grid">
+          <li class="member-item">
+            <div class="member-info">
+              <div class="status-dot active"></div>
+              <img src="https://placeimg.com/100/100/people" alt="직원 프로필" class="member-avatar">
+              <span class="role">조병찬</span>
+              <span class="name">수강생</span>
+              <span class="email">email@email.com</span>
+              <span class="phone">010-1234-5678</span>
+            </div>
+            <button color="skyblue" shape="block" class="detail-btn">상세 보기</button>
+          </li>
+        </ul>
+      </div>
+    </section>
+    `;
+};

--- a/src/components/admin/user-list/UserList.js
+++ b/src/components/admin/user-list/UserList.js
@@ -1,23 +1,68 @@
+import axios from 'axios';
 import './UserList.css';
 
-export const RenderUserList = container => {
-  container.innerHTML = `
-    <section class="member-section">
-      <div class="member-list">
-        <ul class="member-grid">
-          <li class="member-item">
-            <div class="member-info">
-              <div class="status-dot active"></div>
-              <img src="https://placeimg.com/100/100/people" alt="직원 프로필" class="member-avatar">
-              <span class="role">조병찬</span>
-              <span class="name">수강생</span>
-              <span class="email">email@email.com</span>
-              <span class="phone">010-1234-5678</span>
-            </div>
-            <button color="skyblue" shape="block" class="detail-btn">상세 보기</button>
-          </li>
-        </ul>
-      </div>
-    </section>
+export const RenderUserList = async container => {
+  container.innerHTML =
+    '<div class="loading">직원 정보를 가져오는 중입니다.</div>';
+
+  try {
+    const response = await axios.get('../../../../server/data/users.json');
+    const users = response.data;
+
+    const displayUsers = users.slice(0, 10);
+
+    container.innerHTML = `
+      <section class="member-section">
+        <div class="member-list">
+          <ul class="member-grid">
+            ${displayUsers
+              .map(
+                user => `
+                <li class="member-item">
+                  <div class="member-info">
+                    <div class="status-dot active"></div>
+                    <img src="${user.user_image}" alt="${user.user_name}" class="member-avatar">
+                    <span class="role">${user.user_position}</span>
+                    <span class="name">${user.user_name}</span>
+                    <span class="email">${user.user_email}</span>
+                    <span class="phone">${user.user_phone}</span>
+                  </div>
+                  <button color="skyblue" shape="block" class="detail-btn">상세 보기</button>
+                </li>
+              `,
+              )
+              .join('')}
+          </ul>
+        </div>
+      </section>
     `;
+
+    const detailButtons = container.querySelectorAll('.detail-btn');
+    detailButtons.forEach((button, index) => {
+      button.addEventListener('click', () => {
+        handleDetailClick(displayUsers[index]);
+      });
+    });
+  } catch (error) {
+    let errorMessage = '데이터를 불러오는 중 오류가 발생했습니다.';
+
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        errorMessage = `Error ${error.response.status}: ${error.response.data.message || errorMessage}`;
+      } else if (error.request) {
+        errorMessage = '서버로부터 응답을 받지 못했습니다.';
+      }
+    }
+
+    container.innerHTML = `
+      <div class="member-section error">
+        ${errorMessage}
+      </div>
+    `;
+    console.error('Error fetching users:', error);
+  }
+
+  const handleDetailClick = user => {
+    console.log('선택된 직원 정보: ', user);
+  };
 };

--- a/src/components/admin/user-list/UserListHeader.css
+++ b/src/components/admin/user-list/UserListHeader.css
@@ -1,0 +1,27 @@
+.member-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-medium);
+}
+
+.header-controls {
+  display: flex;
+  gap: var(--space-small);
+  align-items: center;
+}
+
+.member-filter {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: var(--font-small);
+  cursor: pointer;
+}
+
+.more-btn {
+  font-size: var(--font-small);
+  border-radius: 8px;
+  padding: 6px 12px;
+  transition: background-color 0.3s;
+}

--- a/src/components/admin/user-list/UserListHeader.js
+++ b/src/components/admin/user-list/UserListHeader.js
@@ -1,4 +1,6 @@
 import { RenderTitle } from '../../common/title/Title';
+import { ADMIN_PATH } from '../../../utils/constants';
+import { navigate } from '../../../utils/navigation';
 import './UserListHeader.css';
 
 export const RenderUserListHeader = container => {
@@ -8,13 +10,20 @@ export const RenderUserListHeader = container => {
         <div class="header-controls">
           <select class="member-filter">
             <option value="all">전체</option>
-            <option value="student">수강생</option>
+            <option value="student">수강생</option> 
             <option value="manager">매니저</option>
           </select>
           <button color="gray" shape="block" class="more-btn">더 보기</button>
       </div>
     </header>
     `;
+
+  // 더 보기 버튼 클릭 시
+  const moreButton = container.querySelector('.more-btn');
+  moreButton.addEventListener('click', e => {
+    e.preventDefault();
+    navigate(ADMIN_PATH.MEMBER);
+  });
 
   const titleContainer = document.querySelector('#titleContainer');
   RenderTitle(titleContainer, '직원 목록');

--- a/src/components/admin/user-list/UserListHeader.js
+++ b/src/components/admin/user-list/UserListHeader.js
@@ -1,0 +1,21 @@
+import { RenderTitle } from '../../common/title/Title';
+import './UserListHeader.css';
+
+export const RenderUserListHeader = container => {
+  container.innerHTML = `
+      <header class="member-header">
+        <div id="titleContainer"></div>
+        <div class="header-controls">
+          <select class="member-filter">
+            <option value="all">전체</option>
+            <option value="student">수강생</option>
+            <option value="manager">매니저</option>
+          </select>
+          <button color="gray" shape="block" class="more-btn">더 보기</button>
+      </div>
+    </header>
+    `;
+
+  const titleContainer = document.querySelector('#titleContainer');
+  RenderTitle(titleContainer, '직원 목록');
+};

--- a/src/components/admin/user-list/UserListHeader.js
+++ b/src/components/admin/user-list/UserListHeader.js
@@ -1,4 +1,5 @@
 import { RenderTitle } from '../../common/title/Title';
+import { RenderUserList } from './UserList';
 import { ADMIN_PATH } from '../../../utils/constants';
 import { navigate } from '../../../utils/navigation';
 import './UserListHeader.css';
@@ -17,6 +18,13 @@ export const RenderUserListHeader = container => {
       </div>
     </header>
     `;
+
+  const memberFilter = container.querySelector('.member-filter');
+  memberFilter.addEventListener('change', e => {
+    const selectedFilter = e.target.value;
+    const userListContainer = document.querySelector('#userListSection');
+    RenderUserList(userListContainer, selectedFilter);
+  });
 
   // 더 보기 버튼 클릭 시
   const moreButton = container.querySelector('.more-btn');

--- a/src/components/common/log-in-form/LogInForm.css
+++ b/src/components/common/log-in-form/LogInForm.css
@@ -56,7 +56,7 @@
 }
 
 .login-btn {
-  background-color: var(--color-sky-blue);
+  background-color: var(--color-skyblue);
   color: black;
   padding: 8px;
   border: none;

--- a/src/components/common/navbar/Navbar.css
+++ b/src/components/common/navbar/Navbar.css
@@ -32,11 +32,11 @@
 }
 
 .menu-item a:hover {
-  background-color: var(--color-sky-blue);
+  background-color: var(--color-skyblue);
 }
 
 a.menu-link.active {
-  background-color: var(--color-sky-blue);
+  background-color: var(--color-skyblue);
 }
 
 @media (width<=900px) {

--- a/src/components/common/title/Title.css
+++ b/src/components/common/title/Title.css
@@ -1,0 +1,5 @@
+.header-title {
+  font-size: var(--font-medium);
+  font-weight: bold;
+  color: black;
+}

--- a/src/components/common/title/Title.js
+++ b/src/components/common/title/Title.js
@@ -1,0 +1,7 @@
+import './Title.css';
+
+export const RenderTitle = (container, titleText) => {
+  container.innerHTML = `
+    <h1 class="header-title">${titleText}</h1>
+  `;
+};

--- a/src/pages/admin/home/Home.css
+++ b/src/pages/admin/home/Home.css
@@ -1,0 +1,4 @@
+.admin-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/src/pages/admin/home/Home.js
+++ b/src/pages/admin/home/Home.js
@@ -1,5 +1,18 @@
+import { RenderUserListHeader } from '../../../components/admin/user-list/UserListHeader';
+import { RenderUserList } from '../../../components/admin/user-list/UserList';
+import './Home.css';
+
 export const RenderAdminHome = container => {
   container.innerHTML = `
-    <div>이 곳은 관리자 홈페이지입니다.</div>
+    <main class="admin-container">
+      <div id="headerSection"></div>
+      <div id="userListSection"></div>
+    </main>
   `;
+
+  const headerSection = document.querySelector('#headerSection');
+  const userListSection = document.querySelector('#userListSection');
+
+  RenderUserListHeader(headerSection);
+  RenderUserList(userListSection);
 };

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -1,0 +1,6 @@
+import Router from '../routes/Router';
+
+export const navigate = path => {
+  history.pushState(null, null, path);
+  Router();
+};


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #24 

## 📝 Task Details

-  `axios`를 사용하여 직원 목록을 불러옵니다.
- 10개만 잘라 스크롤이 가능하게 합니다.
- 필터링 셀렉트를 통해 `전체`, `수강생`, `매니저`로 나누어 각각에 대해 필터링 되도록 합니다.
- `더 보기` 버튼을 클릭 시 직원 관리 페이지로 이동합니다.
- 페이지 이동 시 `navigate` util 함수를 구현합니다.

## 📂 References

https://github.com/user-attachments/assets/50e914a0-b8bc-4338-93ce-37eff9fb25e9

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
