### PR TITLE
[FEAT] 관리자 휴가/공가 관리 페이지를 퍼블리싱합니다.

### DIFF
--- a/server/data/absences.json
+++ b/server/data/absences.json
@@ -8,7 +8,8 @@
     "abs_proof_document": "firbasestorage/document/sick_leave_proof.jpg",
     "abs_created_at": "2024-10-21",
     "abs_start_date": "2024-11-01",
-    "abs_end_date": "2024-11-02"
+    "abs_end_date": "2024-11-02",
+    "abs_status": "대기"
   },
   {
     "user_id": "231231232",
@@ -19,7 +20,8 @@
     "abs_proof_document": "firbasestorage/document/family_event_proof.pdf",
     "abs_created_at": "2024-10-22",
     "abs_start_date": "2024-11-05",
-    "abs_end_date": "2024-11-05"
+    "abs_end_date": "2024-11-05",
+    "abs_status": "대기"
   },
   {
     "user_id": "231231233",
@@ -30,7 +32,8 @@
     "abs_proof_document": "firbasestorage/document/vacation_proof.jpg",
     "abs_created_at": "2024-10-23",
     "abs_start_date": "2024-11-10",
-    "abs_end_date": "2024-11-15"
+    "abs_end_date": "2024-11-15",
+    "abs_status": "대기"
   },
   {
     "user_id": "231231234",
@@ -41,7 +44,8 @@
     "abs_proof_document": "firbasestorage/document/dental_proof.jpg",
     "abs_created_at": "2024-10-24",
     "abs_start_date": "2024-11-03",
-    "abs_end_date": "2024-11-03"
+    "abs_end_date": "2024-11-03",
+    "abs_status": "대기"
   },
   {
     "user_id": "231231235",
@@ -52,7 +56,8 @@
     "abs_proof_document": "firbasestorage/document/wedding_invitation.jpg",
     "abs_created_at": "2024-10-25",
     "abs_start_date": "2024-11-08",
-    "abs_end_date": "2024-11-08"
+    "abs_end_date": "2024-11-08",
+    "abs_status": "대기"
   },
   {
     "user_id": "231231236",
@@ -63,7 +68,8 @@
     "abs_proof_document": "firbasestorage/document/vacation_request.pdf",
     "abs_created_at": "2024-10-26",
     "abs_start_date": "2024-11-12",
-    "abs_end_date": "2024-11-18"
+    "abs_end_date": "2024-11-18",
+    "abs_status": "거부"
   },
   {
     "user_id": "231231237",
@@ -74,7 +80,8 @@
     "abs_proof_document": "firbasestorage/document/allergy_proof.jpg",
     "abs_created_at": "2024-10-27",
     "abs_start_date": "2024-11-02",
-    "abs_end_date": "2024-11-02"
+    "abs_end_date": "2024-11-02",
+    "abs_status": "거부"
   },
   {
     "user_id": "231231238",
@@ -85,7 +92,8 @@
     "abs_proof_document": "firbasestorage/document/school_event_proof.pdf",
     "abs_created_at": "2024-10-28",
     "abs_start_date": "2024-11-06",
-    "abs_end_date": "2024-11-06"
+    "abs_end_date": "2024-11-06",
+    "abs_status": "거부"
   },
   {
     "user_id": "231231239",
@@ -96,7 +104,8 @@
     "abs_proof_document": "firbasestorage/document/family_trip_proof.jpg",
     "abs_created_at": "2024-10-29",
     "abs_start_date": "2024-11-09",
-    "abs_end_date": "2024-11-13"
+    "abs_end_date": "2024-11-13",
+    "abs_status": "거부"
   },
   {
     "user_id": "231231240",
@@ -107,7 +116,8 @@
     "abs_proof_document": "firbasestorage/document/food_poisoning_proof.jpg",
     "abs_created_at": "2024-10-30",
     "abs_start_date": "2024-11-04",
-    "abs_end_date": "2024-11-05"
+    "abs_end_date": "2024-11-05",
+    "abs_status": "거부"
   },
   {
     "user_id": "231231241",
@@ -118,7 +128,8 @@
     "abs_proof_document": "firbasestorage/document/friend_wedding_invitation.jpg",
     "abs_created_at": "2024-10-31",
     "abs_start_date": "2024-11-07",
-    "abs_end_date": "2024-11-07"
+    "abs_end_date": "2024-11-07",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231242",
@@ -129,7 +140,8 @@
     "abs_proof_document": "firbasestorage/document/travel_preparation_proof.jpg",
     "abs_created_at": "2024-11-01",
     "abs_start_date": "2024-11-15",
-    "abs_end_date": "2024-11-15"
+    "abs_end_date": "2024-11-15",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231243",
@@ -140,7 +152,8 @@
     "abs_proof_document": "firbasestorage/document/headache_proof.jpg",
     "abs_created_at": "2024-11-02",
     "abs_start_date": "2024-11-02",
-    "abs_end_date": "2024-11-02"
+    "abs_end_date": "2024-11-02",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231244",
@@ -151,7 +164,8 @@
     "abs_proof_document": "firbasestorage/document/parent_hospital_proof.jpg",
     "abs_created_at": "2024-11-01",
     "abs_start_date": "2024-11-03",
-    "abs_end_date": "2024-11-03"
+    "abs_end_date": "2024-11-03",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231245",
@@ -162,7 +176,8 @@
     "abs_proof_document": "firbasestorage/document/friend_visit_proof.jpg",
     "abs_created_at": "2024-11-02",
     "abs_start_date": "2024-11-20",
-    "abs_end_date": "2024-11-22"
+    "abs_end_date": "2024-11-22",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231246",
@@ -173,7 +188,8 @@
     "abs_proof_document": "firbasestorage/document/fatigue_proof.jpg",
     "abs_created_at": "2024-11-03",
     "abs_start_date": "2024-11-05",
-    "abs_end_date": "2024-11-05"
+    "abs_end_date": "2024-11-05",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231247",
@@ -184,7 +200,8 @@
     "abs_proof_document": "firbasestorage/document/interview_proof.pdf",
     "abs_created_at": "2024-11-04",
     "abs_start_date": "2024-11-25",
-    "abs_end_date": "2024-11-25"
+    "abs_end_date": "2024-11-25",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231248",
@@ -195,7 +212,8 @@
     "abs_proof_document": "firbasestorage/document/family_gathering_proof.jpg",
     "abs_created_at": "2024-11-05",
     "abs_start_date": "2024-11-30",
-    "abs_end_date": "2024-12-01"
+    "abs_end_date": "2024-12-01",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231249",
@@ -206,7 +224,8 @@
     "abs_proof_document": "firbasestorage/document/constipation_proof.jpg",
     "abs_created_at": "2024-11-06",
     "abs_start_date": "2024-11-06",
-    "abs_end_date": "2024-11-06"
+    "abs_end_date": "2024-11-06",
+    "abs_status": "승인"
   },
   {
     "user_id": "231231250",
@@ -217,6 +236,7 @@
     "abs_proof_document": "firbasestorage/document/community_service_proof.jpg",
     "abs_created_at": "2024-11-07",
     "abs_start_date": "2024-11-12",
-    "abs_end_date": "2024-11-12"
+    "abs_end_date": "2024-11-12",
+    "abs_status": "승인"
   }
 ]

--- a/src/components/admin/vacation-management/VacationHeader.css
+++ b/src/components/admin/vacation-management/VacationHeader.css
@@ -1,0 +1,20 @@
+.admin-vacation-management-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-medium);
+}
+
+.admin-vacation-management-header-controls {
+  display: flex;
+  gap: var(--space-small);
+  align-items: center;
+}
+
+.admin-vacation-management-filter {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: var(--font-small);
+  cursor: pointer;
+}

--- a/src/components/admin/vacation-management/VacationHeader.js
+++ b/src/components/admin/vacation-management/VacationHeader.js
@@ -1,0 +1,27 @@
+import { RenderTitle } from '../../common/title/Title';
+import './VacationHeader.css';
+
+export const RenderAdminVacationManagementHeader = container => {
+  container.innerHTML = `
+    <header class="admin-vacation-management-header">
+      <div id="adminVactionTitleContainer"></div>
+      <div class="admin-vacation-management-header-controls">
+        <select class="admin-vacation-management-filter">
+          <option value="vacation-all">전체</option>
+          <option value="vacation">휴가</option>
+          <option value="sick">병가</option>
+          <option value="official">공가</option>
+        </select>
+        <select class="admin-vacation-management-filter">
+          <option value="approved-all">전체</option>
+          <option value="approved">승인</option>
+          <option value="rejected">거부</option>
+          <option value="pending">대기</option>
+        </select>
+      </div>
+    </header>
+  `;
+
+  const titleContainer = document.querySelector('#adminVactionTitleContainer');
+  RenderTitle(titleContainer, '휴가/공가 관리');
+};

--- a/src/components/admin/vacation-management/VacationList.css
+++ b/src/components/admin/vacation-management/VacationList.css
@@ -6,7 +6,7 @@
 
 .admin-vacation-list {
   border-radius: 10px;
-  overflow-y: scroll;
+  overflow-y: auto;
   max-height: 700px;
 }
 
@@ -39,19 +39,40 @@
   flex: 1;
   align-items: center;
   display: grid;
-  grid-template-columns: 60px 60px 60px 60px 100px 150px 150px;
+  grid-template-columns: 40px 60px 60px 60px 100px 150px 150px 80px;
   gap: var(--space-small);
 }
 
 .admin-vacation-info span {
   white-space: nowrap;
+  overflow: hidden;
   text-overflow: ellipsis;
-  padding: 0 var(--space-small);
+}
+
+.admin-vacation-status {
+  padding: var(--space-xsmall) var(--space-small);
+  border-radius: var(--space-small);
+  text-align: center;
+}
+
+.status-승인 {
+  background-color: var(--color-green);
+  color: var(--color-white);
+}
+
+.status-대기 {
+  background-color: var(--color-light-gray);
+  color: var(--color-black);
+}
+
+.status-거부 {
+  background-color: #c85159;
+  color: var(--color-white);
 }
 
 .loading {
   text-align: center;
-  padding: 20px;
+  padding: var(--space-medium);
   color: #6c6c6c;
 }
 
@@ -79,7 +100,7 @@
 }
 
 .detail-label {
-  min-width: 100px;
+  min-width: 60px;
   font-size: 0.9rem;
   font-weight: 700;
 }
@@ -110,10 +131,14 @@
   min-height: 80px;
 }
 
+/* 다운로드 파일 */
 .download-file {
   display: flex;
   align-items: center;
   gap: var(--space-medium);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .detail-download-btn {
@@ -125,6 +150,67 @@
 }
 
 .detail-download-btn:hover {
-  background: var(--color-green-light);
+  background: var(--color-green-dark);
+  color: var(--color-white);
   transition: all 0.3s;
+}
+
+/* 반응형 스타일 */
+@media (max-width: 1200px) {
+  .admin-vacation-info {
+    grid-template-columns: 40px 60px 60px 60px 100px 150px 80px;
+  }
+  .admin-vacation-create-date {
+    display: none;
+  }
+}
+
+@media (max-width: 1000px) {
+  .admin-vacation-info {
+    grid-template-columns: 40px 60px 60px 60px 100px 80px;
+  }
+  .admin-vacation-phone {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-vacation-info {
+    grid-template-columns: 40px 60px 60px 60px 80px;
+  }
+  .admin-vacation-avatar {
+    display: none;
+  }
+}
+
+@media (max-width: 576px) {
+  .admin-vacation-info {
+    grid-template-columns: 40px 60px 60px 60px;
+    gap: var(--space-xsmall);
+    font-size: 0.9rem;
+    padding: var(--space-xsmall);
+  }
+  .admin-vacation-abs-type {
+    display: none;
+  }
+  .detail-item {
+    flex-direction: column;
+    gap: var(--space-small);
+    align-items: flex-start;
+  }
+  .detail-label {
+    font-size: 0.9rem;
+    min-width: auto;
+  }
+  .detail-value {
+    font-size: 0.8rem;
+    width: 100%;
+  }
+  .content-box {
+    padding: var(--space-small);
+    min-height: 60px;
+  }
+  .detail-download-btn {
+    font-size: 0.8rem;
+  }
 }

--- a/src/components/admin/vacation-management/VacationList.css
+++ b/src/components/admin/vacation-management/VacationList.css
@@ -141,18 +141,17 @@
   text-overflow: ellipsis;
 }
 
-.detail-download-btn {
-  background: var(--color-green-light-dark);
-  color: var(--color-black);
-  padding: var(--space-xsmall) var(--space-small);
-  border-radius: var(--space-small);
-  cursor: pointer;
+.approval-button-group {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-small);
+  margin-top: var(--space-medium);
 }
 
-.detail-download-btn:hover {
-  background: var(--color-green-dark);
-  color: var(--color-white);
-  transition: all 0.3s;
+.approval-button {
+  padding: var(--space-small) var(--space-large);
+  border-radius: 8px;
+  cursor: pointer;
 }
 
 /* 반응형 스타일 */
@@ -209,8 +208,5 @@
   .content-box {
     padding: var(--space-small);
     min-height: 60px;
-  }
-  .detail-download-btn {
-    font-size: 0.8rem;
   }
 }

--- a/src/components/admin/vacation-management/VacationList.css
+++ b/src/components/admin/vacation-management/VacationList.css
@@ -1,0 +1,130 @@
+.admin-vacation-list-section {
+  background: var(--color-pale-gray);
+  border-radius: 10px;
+  padding: 20px;
+}
+
+.admin-vacation-list {
+  border-radius: 10px;
+  overflow-y: scroll;
+  max-height: 700px;
+}
+
+.admin-vacation-status-dot {
+  margin-left: var(--space-medium);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #ccc;
+}
+
+.admin-vacation-status-dot.active {
+  background-color: var(--color-green);
+  box-shadow:
+    0 0 4px 2px rgba(76, 175, 80, 0.4),
+    0 0 8px 4px rgba(76, 175, 80, 0.2);
+  filter: blur(1px);
+  animation: glow 2s ease-in-out infinite;
+}
+
+.admin-vacation-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: var(--color-pale-gray);
+  object-fit: cover;
+}
+
+.admin-vacation-info {
+  flex: 1;
+  align-items: center;
+  display: grid;
+  grid-template-columns: 60px 60px 60px 60px 100px 150px 150px;
+  gap: var(--space-small);
+}
+
+.admin-vacation-info span {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 0 var(--space-small);
+}
+
+.loading {
+  text-align: center;
+  padding: 20px;
+  color: #6c6c6c;
+}
+
+.error {
+  text-align: center;
+  padding: 20px;
+  color: #f44336;
+}
+
+/* detail 컨텐츠 */
+.detail-content {
+  padding: var(--space-medium);
+}
+
+.detail-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-medium);
+}
+
+.detail-item {
+  display: flex;
+  gap: var(--space-large);
+  align-items: center;
+}
+
+.detail-label {
+  min-width: 100px;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.detail-value {
+  flex: 1;
+  font-size: 1rem;
+}
+
+.date {
+  color: #130640;
+  font-weight: 500;
+}
+
+.date-separator {
+  margin: 0 var(--space-xsmall);
+}
+
+.detail-content-box {
+  align-items: flex-start;
+}
+
+.content-box {
+  background: var(--color-pale-gray);
+  padding: var(--space-medium);
+  border-radius: var(--space-small);
+  line-height: 1.5;
+  min-height: 80px;
+}
+
+.download-file {
+  display: flex;
+  align-items: center;
+  gap: var(--space-medium);
+}
+
+.detail-download-btn {
+  background: var(--color-green-light-dark);
+  color: var(--color-black);
+  padding: var(--space-xsmall) var(--space-small);
+  border-radius: var(--space-small);
+  cursor: pointer;
+}
+
+.detail-download-btn:hover {
+  background: var(--color-green-light);
+  transition: all 0.3s;
+}

--- a/src/components/admin/vacation-management/VacationList.js
+++ b/src/components/admin/vacation-management/VacationList.js
@@ -15,7 +15,7 @@ export const RenderAdminVacationManagementList = async container => {
     const absences = absencesResponse.data;
     const users = usersResponse.data;
 
-    const mergedData = absences.map(absence => {
+    const absenceUsersData = absences.map(absence => {
       const user = users.find(user => user.user_id === absence.user_id);
       return {
         ...absence,
@@ -35,6 +35,7 @@ export const RenderAdminVacationManagementList = async container => {
         <span class="admin-vacation-position">${item.user_position}</span>
         <span class="admin-vacation-phone">${item.user_phone}</span>
         <span class="admin-vacation-create-date">${item.abs_created_at}</span>
+        <span class="admin-vacation-status status-${item.abs_status}">${item.abs_status}</span>
       </div>
     `;
 
@@ -49,9 +50,9 @@ export const RenderAdminVacationManagementList = async container => {
           <div class="detail-item">
             <div class="detail-label">휴가 기간</div>
             <div class="detail-value">
-            <span class="date">${item.abs_start_date}</span>
-            <span class="date-separator">~</span>
-            <span class="date">${item.abs_end_date}</span>
+              <span class="date">${item.abs_start_date}</span>
+              <span class="date-separator">~</span>
+              <span class="date">${item.abs_end_date}</span>
             </div>
           </div>
 
@@ -75,7 +76,7 @@ export const RenderAdminVacationManagementList = async container => {
       <section class="admin-vacation-list-section">
         <div class="admin-vacation-list">
             ${Accordion({
-              items: mergedData,
+              items: absenceUsersData,
               renderHeader,
               renderContent,
             })}

--- a/src/components/admin/vacation-management/VacationList.js
+++ b/src/components/admin/vacation-management/VacationList.js
@@ -83,52 +83,52 @@ export const RenderAdminVacationManagementList = async container => {
 
     // 아코디언 헤더
     const renderHeader = item => `
-      <div class="admin-vacation-info">
+      <header class="admin-vacation-info">
         <div class="admin-vacation-status-dot active"></div>
         <img src="${item.user_image}" alt="${item.user_name}" class="admin-vacation-avatar">
         <span class="admin-vacation-abs-type">${item.abs_type}</span>
         <span class="admin-vacation-name">${item.user_name}</span>
         <span class="admin-vacation-position">${item.user_position}</span>
         <span class="admin-vacation-phone">${item.user_phone}</span>
-        <span class="admin-vacation-create-date">${item.abs_created_at}</span>
+        <time class="admin-vacation-create-date">${item.abs_created_at}</time>
         <span class="admin-vacation-status status-${item.abs_status}">${item.abs_status}</span>
-      </div>
+      </header>
     `;
 
     // 아코디언 컨텐츠
     const renderContent = (item, index) => `
-      <div class="detail-content">
+      <article class="detail-content">
         <div class="detail-grid">
-          <div class="detail-item">
-            <div class="detail-label">휴가 제목</div>
+          <section class="detail-item">
+            <h3 class="detail-label">휴가 제목</h3>
             <div class="detail-value">${item.abs_title}</div>
-          </div>
+          </section>
           
           <div class="detail-item">
-            <div class="detail-label">휴가 기간</div>
+            <h3 class="detail-label">휴가 기간</h3>
             <div class="detail-value">
-              <span class="date">${item.abs_start_date}</span>
+              <time class="date">${item.abs_start_date}</time>
               <span class="date-separator">~</span>
-              <span class="date">${item.abs_end_date}</span>
+              <time class="date">${item.abs_end_date}</time>
             </div>
           </div>
 
-          <div class="detail-item">
-            <div class="detail-label">첨부 파일</div>
+          <section class="detail-item">
+            <h3 class="detail-label">첨부 파일</h3>
             <div class="download-file">
-              <div class="detail-value">FE_${item.user_name}_${item.abs_type}.pdf</div>
+              <p class="detail-value">FE_${item.user_name}_${item.abs_type}.pdf</p>
               ${downloadButton.outerHTML}
             </div>
-          </div>
+          </section>
 
-          <div class="detail-item detail-content-box">
-            <div class="detail-label">휴가 내용</div>
-            <div class="detail-value content-box" data-index="${index}">${item.abs_content}</div>
-          </div>
+          <section class="detail-item detail-content-box">
+            <h3 class="detail-label">휴가 내용</h3>
+            <p class="detail-value content-box" data-index="${index}">${item.abs_content}</p>
+          </section>
         </div>
 
         ${renderButtons(item.abs_status)}
-      </div>
+      </article>
     `;
 
     // 아코디언 렌더링

--- a/src/components/admin/vacation-management/VacationList.js
+++ b/src/components/admin/vacation-management/VacationList.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { Accordion } from '../../ui/accordion/Accordion';
+import { Button } from '../../ui/button/Button';
 import './VacationList.css';
 
 export const RenderAdminVacationManagementList = async container => {
@@ -26,6 +27,61 @@ export const RenderAdminVacationManagementList = async container => {
       };
     });
 
+    // 다운로드 버튼
+    const downloadButton = new Button({
+      text: '다운로드',
+      color: 'white',
+      shape: 'line',
+      padding: 'var(--space-xsmall) var(--space-small)',
+    });
+
+    // 승인, 거부, 대기 버튼
+    const renderButtons = status => {
+      switch (status) {
+        case '승인':
+          return '';
+        case '거부': {
+          const cancelButton = new Button({
+            text: '거부 취소',
+            color: 'gray',
+            shape: 'block',
+            padding: 'var(--space-small) var(--space-large)',
+          });
+
+          return `
+            <div class="approval-button-group">
+              ${cancelButton.outerHTML}
+            </div>
+          `;
+        }
+        case '대기': {
+          const approveButton = new Button({
+            text: '승인하기',
+            color: 'skyblue',
+            shape: 'block',
+            padding: 'var(--space-small) var(--space-large)',
+          });
+
+          const rejectButton = new Button({
+            text: '거부하기',
+            color: 'coral',
+            shape: 'block',
+            padding: 'var(--space-small) var(--space-large)',
+          });
+
+          return `
+            <div class="approval-button-group">
+              ${approveButton.outerHTML}
+              ${rejectButton.outerHTML}
+            </div>
+          `;
+        }
+        default:
+          return '';
+      }
+    };
+
+    // 아코디언 헤더
     const renderHeader = item => `
       <div class="admin-vacation-info">
         <div class="admin-vacation-status-dot active"></div>
@@ -39,6 +95,7 @@ export const RenderAdminVacationManagementList = async container => {
       </div>
     `;
 
+    // 아코디언 컨텐츠
     const renderContent = (item, index) => `
       <div class="detail-content">
         <div class="detail-grid">
@@ -60,7 +117,7 @@ export const RenderAdminVacationManagementList = async container => {
             <div class="detail-label">첨부 파일</div>
             <div class="download-file">
               <div class="detail-value">FE_${item.user_name}_${item.abs_type}.pdf</div>
-              <button class="detail-download-btn">다운로드</button>
+              ${downloadButton.outerHTML}
             </div>
           </div>
 
@@ -68,10 +125,13 @@ export const RenderAdminVacationManagementList = async container => {
             <div class="detail-label">휴가 내용</div>
             <div class="detail-value content-box" data-index="${index}">${item.abs_content}</div>
           </div>
-          </div>
+        </div>
+
+        ${renderButtons(item.abs_status)}
       </div>
     `;
 
+    // 아코디언 렌더링
     container.innerHTML = `
       <section class="admin-vacation-list-section">
         <div class="admin-vacation-list">

--- a/src/components/admin/vacation-management/VacationList.js
+++ b/src/components/admin/vacation-management/VacationList.js
@@ -1,0 +1,102 @@
+import axios from 'axios';
+
+import { Accordion } from '../../ui/accordion/Accordion';
+import './VacationList.css';
+
+export const RenderAdminVacationManagementList = async container => {
+  container.innerHTML = `<div class="loading">휴가 정보를 가져오는 중입니다.</div>`;
+
+  try {
+    const [absencesResponse, usersResponse] = await Promise.all([
+      axios.get('../../../../server/data/absences.json'),
+      axios.get('../../../../server/data/users.json'),
+    ]);
+
+    const absences = absencesResponse.data;
+    const users = usersResponse.data;
+
+    const mergedData = absences.map(absence => {
+      const user = users.find(user => user.user_id === absence.user_id);
+      return {
+        ...absence,
+        user_name: user.user_name,
+        user_image: user.user_image,
+        user_phone: user.user_phone,
+        user_position: user.user_position,
+      };
+    });
+
+    const renderHeader = item => `
+      <div class="admin-vacation-info">
+        <div class="admin-vacation-status-dot active"></div>
+        <img src="${item.user_image}" alt="${item.user_name}" class="admin-vacation-avatar">
+        <span class="admin-vacation-abs-type">${item.abs_type}</span>
+        <span class="admin-vacation-name">${item.user_name}</span>
+        <span class="admin-vacation-position">${item.user_position}</span>
+        <span class="admin-vacation-phone">${item.user_phone}</span>
+        <span class="admin-vacation-create-date">${item.abs_created_at}</span>
+      </div>
+    `;
+
+    const renderContent = (item, index) => `
+      <div class="detail-content">
+        <div class="detail-grid">
+          <div class="detail-item">
+            <div class="detail-label">휴가 제목</div>
+            <div class="detail-value">${item.abs_title}</div>
+          </div>
+          
+          <div class="detail-item">
+            <div class="detail-label">휴가 기간</div>
+            <div class="detail-value">
+            <span class="date">${item.abs_start_date}</span>
+            <span class="date-separator">~</span>
+            <span class="date">${item.abs_end_date}</span>
+            </div>
+          </div>
+
+          <div class="detail-item">
+            <div class="detail-label">첨부 파일</div>
+            <div class="download-file">
+              <div class="detail-value">FE_${item.user_name}_${item.abs_type}.pdf</div>
+              <button class="detail-download-btn">다운로드</button>
+            </div>
+          </div>
+
+          <div class="detail-item detail-content-box">
+            <div class="detail-label">휴가 내용</div>
+            <div class="detail-value content-box" data-index="${index}">${item.abs_content}</div>
+          </div>
+          </div>
+      </div>
+    `;
+
+    container.innerHTML = `
+      <section class="admin-vacation-list-section">
+        <div class="admin-vacation-list">
+            ${Accordion({
+              items: mergedData,
+              renderHeader,
+              renderContent,
+            })}
+        </div>
+      </section>
+    `;
+  } catch (error) {
+    let errorMessage = '데이터를 불러오는 중 오류가 발생했습니다.';
+
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        errorMessage = `Error ${error.response.status}: ${error.response.data.message || errorMessage}`;
+      } else if (error.request) {
+        errorMessage = '서버로부터 응답을 받지 못했습니다.';
+      }
+    }
+
+    container.innerHTML = `
+      <div class="admin-vacation-section error">
+        ${errorMessage}
+      </div>
+    `;
+  }
+};

--- a/src/components/ui/accordion/Accordion.css
+++ b/src/components/ui/accordion/Accordion.css
@@ -21,8 +21,12 @@
 
 .accordion-detail {
   overflow: hidden;
-  display: none;
-  transition: all 0.3s ease;
+  max-height: 0;
+  opacity: 0;
+  transition:
+    max-height 0.3s ease-in-out,
+    opacity 0.3s ease-in-out,
+    padding 0.3s ease-in-out;
   padding: 0 var(--space-medium);
 }
 

--- a/src/components/ui/accordion/Accordion.css
+++ b/src/components/ui/accordion/Accordion.css
@@ -1,0 +1,57 @@
+.accordion-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.accordion-item {
+  background: var(--color-white);
+  border-radius: var(--space-small);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition: all 0.3s ease;
+}
+
+.accordion-item:hover {
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.accordion-detail {
+  overflow: hidden;
+  display: none;
+  transition: all 0.3s ease;
+  padding: 0 var(--space-medium);
+}
+
+.accordion-header {
+  padding: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.accordion-button > .material-symbols-rounded {
+  font-size: 2rem;
+  transition: transform 0.3s ease-in-out;
+  transform: rotate(0deg);
+  border-radius: 50%;
+}
+
+.accordion-button:hover > .material-symbols-rounded {
+  background: var(--color-skyblue);
+  transition: all 0.3s ease;
+  border-radius: 50%;
+}
+
+/* 열린 상태일 때 180도 회전 */
+.accordion-item.open .accordion-button > .material-symbols-rounded {
+  transform: rotate(180deg);
+}
+
+/* 닫힌 상태일 때 0도 회전 */
+.accordion-item:not(.open) .accordion-button > .material-symbols-rounded {
+  transform: rotate(0deg);
+}

--- a/src/components/ui/accordion/Accordion.js
+++ b/src/components/ui/accordion/Accordion.js
@@ -15,12 +15,14 @@ export const Accordion = ({ items, renderHeader, renderContent }) => {
     allItems.forEach(item => {
       item.classList.remove('open');
       const itemDetail = item.querySelector('.accordion-detail');
-      itemDetail.style.display = 'none';
+      itemDetail.style.maxHeight = '0';
+      itemDetail.style.opacity = '0';
     });
 
     if (!isOpen) {
       accordionItem.classList.add('open');
-      detail.style.display = 'block';
+      detail.style.maxHeight = `${detail.scrollHeight}px`;
+      detail.style.opacity = '1';
     }
   };
 

--- a/src/components/ui/accordion/Accordion.js
+++ b/src/components/ui/accordion/Accordion.js
@@ -1,0 +1,48 @@
+import './Accordion.css';
+
+export const Accordion = ({ items, renderHeader, renderContent }) => {
+  const handleClick = e => {
+    e.stopPropagation();
+
+    const button = e.currentTarget;
+    const accordionItem = button.closest('.accordion-item');
+    const detail = accordionItem.querySelector('.accordion-detail');
+    const isOpen = accordionItem.classList.contains('open');
+
+    const allItems =
+      accordionItem.parentElement.querySelectorAll('.accordion-item');
+    // 한 번에 하나의 아이템만 열리도록 처리
+    allItems.forEach(item => {
+      item.classList.remove('open');
+      const itemDetail = item.querySelector('.accordion-detail');
+      itemDetail.style.display = 'none';
+    });
+
+    if (!isOpen) {
+      accordionItem.classList.add('open');
+      detail.style.display = 'block';
+    }
+  };
+
+  return `
+      <ul class="accordion-list">
+        ${items
+          .map(
+            item => `
+          <li class="accordion-item">
+            <div class="accordion-header">
+              ${renderHeader(item)}
+              <button class="accordion-button" onclick="(${handleClick.toString()})(event)">
+                <span class="material-symbols-rounded">keyboard_arrow_down</span>
+              </button>
+            </div>
+            <div class="accordion-detail">
+              ${renderContent(item)}
+            </div>
+          </li>
+        `,
+          )
+          .join('')}
+      </ul>
+    `;
+};

--- a/src/pages/admin/vacation-management/VacationManagement.css
+++ b/src/pages/admin/vacation-management/VacationManagement.css
@@ -1,0 +1,6 @@
+.admin-vacation-management-container {
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}

--- a/src/pages/admin/vacation-management/VacationManagement.js
+++ b/src/pages/admin/vacation-management/VacationManagement.js
@@ -1,5 +1,15 @@
+import { RenderAdminVacationManagementHeader } from '../../../components/admin/vacation-management/VacationHeader';
+
 export const RenderAdminVacationManagement = container => {
   container.innerHTML = `
-    <div>이 곳은 관리자 휴가/공가 관리 페이지입니다.</div>
+    <main class="admin-vacation-management-container">
+      <div id="adminVacationManagementHeaderSection"></div>
+    </main>
   `;
+
+  const headerSection = document.querySelector(
+    '#adminVacationManagementHeaderSection',
+  );
+
+  RenderAdminVacationManagementHeader(headerSection);
 };

--- a/src/pages/admin/vacation-management/VacationManagement.js
+++ b/src/pages/admin/vacation-management/VacationManagement.js
@@ -1,15 +1,21 @@
 import { RenderAdminVacationManagementHeader } from '../../../components/admin/vacation-management/VacationHeader';
+import { RenderAdminVacationManagementList } from '../../../components/admin/vacation-management/VacationList';
 
 export const RenderAdminVacationManagement = container => {
   container.innerHTML = `
     <main class="admin-vacation-management-container">
       <div id="adminVacationManagementHeaderSection"></div>
+      <div id="adminVacationMangementListSection"></div>
     </main>
   `;
 
   const headerSection = document.querySelector(
     '#adminVacationManagementHeaderSection',
   );
+  const memberListSection = document.querySelector(
+    '#adminVacationMangementListSection',
+  );
 
   RenderAdminVacationManagementHeader(headerSection);
+  RenderAdminVacationManagementList(memberListSection);
 };

--- a/src/routes/Router.js
+++ b/src/routes/Router.js
@@ -11,6 +11,7 @@ import {
   RenderUserPeer,
   RenderNotFound,
   RenderLogIn,
+  RenderAdminVacationManagement,
 } from '../pages';
 import {
   ADMIN_PATH,
@@ -140,6 +141,8 @@ export default function Router() {
     RenderAdminHome(contentEl);
   } else if (path === ADMIN_PATH.MEMBER) {
     RenderAdminMemberManagement(contentEl);
+  } else if (path === ADMIN_PATH.VACATION) {
+    RenderAdminVacationManagement(contentEl);
   } else if (path === USER_PATH.HOME) {
     RenderUserHome(contentEl);
   } else if (path === USER_PATH.NOTICE) {


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #49 

## 📝 Task Details

- 직원의 모든 휴가/공가 정보를 확인할 수 있습니다.
- 각 휴가 클릭 시 아코디언이 펼쳐지도록 아코디언 ui를 제작합니다.
- 아코디언 ui는 펼칠 때와 닫힐 때 애니메이션이 적용되며 오른쪽 화살표 버튼을 누르면 열리도록 했습니다.
- 오른쪽 상단에는 휴가 종류(`휴가`, `공가`, `병가`) 셀렉트, 승인 여부(`승인`, `대기`, `거부`) 셀렉트 넣었습니다. (아직 필터링은 구현 X → 다음 PR에서 구현 예정)
- 승인 여부에 따라 아코디언 컨텐츠 내부 `승인하기`, `거부하기`, `거부 취소`를 `switch`문을 통해 조정하였습니다.
- 모바일 환경에서도 ui가 깨지지 않도록 미디어 쿼리를 통해 스타일을 조정했습니다.

## 📂 References

https://github.com/user-attachments/assets/c4612de6-0d4d-4f62-b612-a81379c97190

https://github.com/user-attachments/assets/14774785-0953-4c60-959d-c38bd9b8ebf9

## 💖 Review Requirements

### 나는 바보
- `Button` 컴포넌트 사용에서 계속 헤맸는데 `color`부분에 `global.css`에 있는 컬러를 넣으면 되는줄 알고 넣었다가 색상 적용이 안돼서 ai한테 계속 물어보며 진행했는데 결국 제가 코드를 잘 뒤져보니 `Button.css`에 지정된 색상만 `Button` 컴포넌트에 `color`로 지정할 수 있었네요,, 이건 저의 너무나도 ~~시간을 엄청나게 날려먹은~~ 바보같은 실수였습니다. 

### 고민사항
- 헤더와 컨텐츠 부분을 따로 컴포넌트로 분리할까도 많이 고민했었는데 투머치한 분리라고 생각했기 때문에 분리하지 않았습니다. 코드 길지만 읽기 쉽도록 제작했습니다 :)
- 아코디언 부분에서는 아이템 전체를 클릭 시 펼쳐지도록 할까 고민을 많이 했습니다. 하지만 무분별하게 클릭하다 보면 정신이 없을 것이라고 생각하며 화살표 버튼 클릭 시에만 아코디언이 동작하도록 하였습니다.

### 소식
- 현재 `VacationList.js` 파일이 매우 길지만 막상 읽어보면 내용은 바로 이해가 되기 쉬울 겁니다.
- 아코디언 ui는 `ui` 폴더 안에 넣어놨으니 사용하실 분은 사용하시면 될 것 같습니다.

```
container.innerHTML = `
      <section class="admin-vacation-list-section">
        <div class="admin-vacation-list">
            ${Accordion({
              items: absenceUsersData,
              renderHeader,
              renderContent,
            })}
        </div>
      </section>
    `;
``` 
`Accordion` 컴포넌트를 차근차근 살펴본 후 사용할 위 아코디언을 사용할 컴포넌트로 가서 위 코드와 같이 사용하면 됩니다!