### PR TITLE
[FEAT] 관리자 휴가/공가 관리 페이지에서 셀렉트에 따른 필터링을 합니다.

### DIFF
--- a/src/components/admin/vacation-management/VacationHeader.js
+++ b/src/components/admin/vacation-management/VacationHeader.js
@@ -1,18 +1,19 @@
 import { RenderTitle } from '../../common/title/Title';
 import './VacationHeader.css';
+import { RenderAdminVacationManagementList } from './VacationList';
 
 export const RenderAdminVacationManagementHeader = container => {
   container.innerHTML = `
     <header class="admin-vacation-management-header">
       <div id="adminVactionTitleContainer"></div>
       <div class="admin-vacation-management-header-controls">
-        <select class="admin-vacation-management-filter">
+        <select class="admin-vacation-management-filter" id="typeFilter">
           <option value="vacation-all">전체</option>
           <option value="vacation">휴가</option>
           <option value="sick">병가</option>
           <option value="official">공가</option>
         </select>
-        <select class="admin-vacation-management-filter">
+        <select class="admin-vacation-management-filter" id="statusFilter">
           <option value="approved-all">전체</option>
           <option value="approved">승인</option>
           <option value="rejected">거부</option>
@@ -21,6 +22,23 @@ export const RenderAdminVacationManagementHeader = container => {
       </div>
     </header>
   `;
+
+  const typeFilter = container.querySelector('#typeFilter');
+  const statusFilter = container.querySelector('#statusFilter');
+
+  const filteredList = () => {
+    const filters = {
+      type: typeFilter.value,
+      status: statusFilter.value,
+    };
+    const vacationListContainer = document.querySelector(
+      '#adminVacationMangementListSection',
+    );
+    RenderAdminVacationManagementList(vacationListContainer, filters);
+  };
+
+  typeFilter.addEventListener('change', filteredList);
+  statusFilter.addEventListener('change', filteredList);
 
   const titleContainer = document.querySelector('#adminVactionTitleContainer');
   RenderTitle(titleContainer, '휴가/공가 관리');

--- a/src/components/admin/vacation-management/VacationList.js
+++ b/src/components/admin/vacation-management/VacationList.js
@@ -4,7 +4,10 @@ import { Accordion } from '../../ui/accordion/Accordion';
 import { Button } from '../../ui/button/Button';
 import './VacationList.css';
 
-export const RenderAdminVacationManagementList = async container => {
+export const RenderAdminVacationManagementList = async (
+  container,
+  filter = { type: 'vacation-all', status: 'approved-all' },
+) => {
   container.innerHTML = `<div class="loading">휴가 정보를 가져오는 중입니다.</div>`;
 
   try {
@@ -16,7 +19,7 @@ export const RenderAdminVacationManagementList = async container => {
     const absences = absencesResponse.data;
     const users = usersResponse.data;
 
-    const absenceUsersData = absences.map(absence => {
+    let absenceUsersData = absences.map(absence => {
       const user = users.find(user => user.user_id === absence.user_id);
       return {
         ...absence,
@@ -26,6 +29,29 @@ export const RenderAdminVacationManagementList = async container => {
         user_position: user.user_position,
       };
     });
+
+    // 필터링
+    if (filter.type !== 'vacation-all') {
+      const absType = {
+        vacation: '휴가',
+        sick: '병가',
+        official: '공가',
+      };
+      absenceUsersData = absenceUsersData.filter(
+        absence => absence.abs_type === absType[filter.type],
+      );
+    }
+
+    if (filter.status !== 'approved-all') {
+      const statusType = {
+        approved: '승인',
+        rejected: '거부',
+        pending: '대기',
+      };
+      absenceUsersData = absenceUsersData.filter(
+        absence => absence.abs_status === statusType[filter.status],
+      );
+    }
 
     // 다운로드 버튼
     const downloadButton = new Button({

--- a/src/components/admin/vacation-management/VacationList.js
+++ b/src/components/admin/vacation-management/VacationList.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import { Accordion } from '../../ui/accordion/Accordion';
 import { Button } from '../../ui/button/Button';
+import { sortByName } from '../../../utils/sortByName';
 import './VacationList.css';
 
 export const RenderAdminVacationManagementList = async (
@@ -29,6 +30,7 @@ export const RenderAdminVacationManagementList = async (
         user_position: user.user_position,
       };
     });
+    let sortedAbsenceUsersData = sortByName(absenceUsersData);
 
     // 필터링
     if (filter.type !== 'vacation-all') {
@@ -37,7 +39,7 @@ export const RenderAdminVacationManagementList = async (
         sick: '병가',
         official: '공가',
       };
-      absenceUsersData = absenceUsersData.filter(
+      sortedAbsenceUsersData = sortedAbsenceUsersData.filter(
         absence => absence.abs_type === absType[filter.type],
       );
     }
@@ -48,7 +50,7 @@ export const RenderAdminVacationManagementList = async (
         rejected: '거부',
         pending: '대기',
       };
-      absenceUsersData = absenceUsersData.filter(
+      sortedAbsenceUsersData = sortedAbsenceUsersData.filter(
         absence => absence.abs_status === statusType[filter.status],
       );
     }
@@ -162,7 +164,7 @@ export const RenderAdminVacationManagementList = async (
       <section class="admin-vacation-list-section">
         <div class="admin-vacation-list">
             ${Accordion({
-              items: absenceUsersData,
+              items: sortedAbsenceUsersData,
               renderHeader,
               renderContent,
             })}

--- a/src/pages/admin/member/member-management/MemberManagement.js
+++ b/src/pages/admin/member/member-management/MemberManagement.js
@@ -1,4 +1,4 @@
-import { ApiClient } from '../../../../apis/apiClient';
+import { ApiClient } from '../../../../apis/ApiClient';
 import { Button } from '../../../../components';
 import { Pagenation } from '../../../../components/common/pagenation/Pagenation';
 import './MemberManagement.css';

--- a/src/utils/sortByName.js
+++ b/src/utils/sortByName.js
@@ -1,5 +1,13 @@
 export const sortByName = users => {
   return users.sort((a, b) => {
+    // 휴가 승인 상태로 정렬 (대기 > 승인 > 거부)
+    if (a.abs_status && b.abs_status) {
+      if (a.abs_status === '대기' && b.abs_status !== '대기') return -1;
+      if (a.abs_status !== '대기' && b.abs_status === '대기') return 1;
+      if (a.abs_status === '승인' && b.abs_status === '거부') return -1;
+      if (a.abs_status === '거부' && b.abs_status === '승인') return 1;
+    }
+
     // 매니저가 먼저 나오도록 정렬
     if (a.user_position === '매니저' && b.user_position === '수강생') return -1;
     if (a.user_position === '수강생' && b.user_position === '매니저') return 1;


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #57 

## 📝 Task Details

- 휴가 종류 필터링
- 휴가 승인 여부 필터링
- 휴가 승인 여부 → 직책 → 이름 순으로 정렬을 합니다.
- 휴가 승인 여부에서는 (대기 → 승인 → 거부) 순으로 정렬을 합니다.

## 📂 References

https://github.com/user-attachments/assets/837d731f-8801-4955-a5e4-78709771704e

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
