### PR TITLE
[FEAT] 관리자 - 공지 관리 페이지를 퍼블리싱합니다.

### DIFF
--- a/src/components/admin/home/notice/Notice.js
+++ b/src/components/admin/home/notice/Notice.js
@@ -1,30 +1,13 @@
-import axios from 'axios';
+import { RenderAdminNoticeList } from '../../../common/notice/AdminNoticeList';
 import { RenderNoticeItem } from './NoticeItem';
 import './Notice.css';
 
 export const RenderAdminHomeNotice = async container => {
-  try {
-    const response = await axios.get(
-      '../../../../../server/data/company_posts.json',
-    );
-    const posts = response.data.sort(
-      (a, b) => new Date(b.updated_at) - new Date(a.updated_at),
-    );
-
-    container.innerHTML = `
-          <ul class="admin-notice-list">
-            ${posts
-              .map(
-                post => `
-                <li class="admin-notice-container" id="admin-notice-${post.post_id}">
-                  ${RenderNoticeItem(post)}
-                </li>
-                `,
-              )
-              .join('')}
-          </ul>
-        `;
-  } catch (e) {
-    console.error('공지를 가져오는 과정에서 에러가 발생했습니다: ', e);
-  }
+  await RenderAdminNoticeList({
+    container,
+    renderItemComponent: RenderNoticeItem,
+    containerClassName: 'admin-notice-list',
+    itemClassName: 'admin-notice-container',
+    itemIdPrefix: 'admin-notice',
+  });
 };

--- a/src/components/admin/home/notice/NoticeItem.js
+++ b/src/components/admin/home/notice/NoticeItem.js
@@ -1,21 +1,14 @@
+import { RenderAdminNoticeItem } from '../../../common/notice/AdminNoticeItem';
 import './NoticeItem.css';
 
 export const RenderNoticeItem = post => {
-  return `
-    <div class="notice-item">
-      <div class="notice-image">
-        <img src="${post.post_image}" alt="${post.post_title}" />
-      </div>
-      <div class="notice-content">
-        <div class="notice-title">${post.post_title}</div>
-        <div class="notice-description">${post.post_description}</div>
-        <div class="notice-date">
-          <span class="material-symbols-rounded">
-            update
-          </span>
-          <p>${new Date(post.updated_at).toLocaleString()}</p>
-        </div>
-      </div>
-    </div>
-  `;
+  return RenderAdminNoticeItem({
+    post,
+    itemContainerClassName: 'notice-item',
+    imageClassName: 'notice-image',
+    contentContainerClassName: 'notice-content',
+    contentTitleClassName: 'notice-title',
+    contentDescriptionClassName: 'notice-description',
+    contentDateClassName: 'notice-date',
+  });
 };

--- a/src/components/admin/notice-management/NoticeManagementHeader.css
+++ b/src/components/admin/notice-management/NoticeManagementHeader.css
@@ -11,20 +11,12 @@
   align-items: center;
 }
 
-.admin-notice-search {
-  display: flex;
-  gap: 0.8rem;
-  align-items: center;
-  cursor: pointer;
-}
-
-.admin-notice-search input[type='text'] {
-  padding: var(--space-small);
+.admin-notice-search-input {
   max-height: 30px;
 }
 
 @media screen and (max-width: 600px) {
-  .admin-notice-search input[type='text'] {
+  .admin-notice-search-input {
     max-width: 150px;
   }
 }

--- a/src/components/admin/notice-management/NoticeManagementHeader.css
+++ b/src/components/admin/notice-management/NoticeManagementHeader.css
@@ -1,0 +1,30 @@
+.admin-notice-management-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-medium);
+}
+
+.admin-notice-management-header-controls {
+  display: flex;
+  gap: var(--space-small);
+  align-items: center;
+}
+
+.admin-notice-search {
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  cursor: pointer;
+}
+
+.admin-notice-search input[type='text'] {
+  padding: var(--space-small);
+  max-height: 30px;
+}
+
+@media screen and (max-width: 600px) {
+  .admin-notice-search input[type='text'] {
+    max-width: 150px;
+  }
+}

--- a/src/components/admin/notice-management/NoticeManagementHeader.js
+++ b/src/components/admin/notice-management/NoticeManagementHeader.js
@@ -33,5 +33,5 @@ export const RenderAdminNoticeManagementHeader = container => {
   moreBtnContainer.appendChild(moreButton);
 
   const titleContainer = document.querySelector('#adminNoticeTitleContainer');
-  RenderTitle(titleContainer, '공지사항 관리');
+  RenderTitle(titleContainer, '공지사항 (0개)');
 };

--- a/src/components/admin/notice-management/NoticeManagementHeader.js
+++ b/src/components/admin/notice-management/NoticeManagementHeader.js
@@ -4,19 +4,21 @@ import { Button } from '../../ui/button/Button';
 import { ADMIN_PATH } from '../../../utils/constants';
 import './NoticeManagementHeader.css';
 
-export const RenderAdminNoticeManagementHeader = container => {
+export const RenderAdminNoticeManagementHeader = (container, onSearch) => {
   container.innerHTML = `
         <header class="admin-notice-management-header">
             <div id="adminNoticeTitleContainer"></div>
             <div class="admin-notice-management-header-controls">
-              <div class="admin-notice-search">
-                <input type="text" class="admin-notice-search-input" placeholder="Search"/>
-                <span class="material-symbols-rounded">search</span> 
-              </div>
+              <input type="text" class="admin-notice-search-input" placeholder="Search"/>
               <div class="admin-notice-management-more-button"></div>
             </div>
         </header>
     `;
+
+  const searchInput = document.querySelector('.admin-notice-search-input');
+  searchInput.addEventListener('input', e => {
+    onSearch(e.target.value);
+  });
 
   const moreBtnContainer = document.querySelector(
     '.admin-notice-management-more-button',

--- a/src/components/admin/notice-management/NoticeManagementHeader.js
+++ b/src/components/admin/notice-management/NoticeManagementHeader.js
@@ -1,0 +1,37 @@
+import navigate from '../../../utils/navigation';
+import { RenderTitle } from '../../common/title/Title';
+import { Button } from '../../ui/button/Button';
+import { ADMIN_PATH } from '../../../utils/constants';
+import './NoticeManagementHeader.css';
+
+export const RenderAdminNoticeManagementHeader = container => {
+  container.innerHTML = `
+        <header class="admin-notice-management-header">
+            <div id="adminNoticeTitleContainer"></div>
+            <div class="admin-notice-management-header-controls">
+              <div class="admin-notice-search">
+                <input type="text" class="admin-notice-search-input" placeholder="Search"/>
+                <span class="material-symbols-rounded">search</span> 
+              </div>
+              <div class="admin-notice-management-more-button"></div>
+            </div>
+        </header>
+    `;
+
+  const moreBtnContainer = document.querySelector(
+    '.admin-notice-management-more-button',
+  );
+  const moreButton = new Button({
+    text: '업로드',
+    color: 'skyblue',
+    shape: 'block',
+    padding: '6px var(--space-medium)',
+    cursor: 'pointer',
+    onClick: () => navigate(ADMIN_PATH.NOTICE_UPLOAD),
+  });
+
+  moreBtnContainer.appendChild(moreButton);
+
+  const titleContainer = document.querySelector('#adminNoticeTitleContainer');
+  RenderTitle(titleContainer, '공지사항 관리');
+};

--- a/src/components/admin/notice-management/NoticeManagementItem.css
+++ b/src/components/admin/notice-management/NoticeManagementItem.css
@@ -1,0 +1,62 @@
+.notice-manage-item {
+  width: 100%;
+  height: 100%;
+}
+
+.notice-manage-image {
+  width: 100%;
+  height: 220px;
+}
+
+.notice-manage-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--base-border-radius) var(--base-border-radius) 0 0;
+}
+
+.notice-manage-content {
+  padding: var(--space-small);
+  flex: 1;
+  flex-basis: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-small);
+}
+
+.notice-manage-title {
+  font-size: var(--font-medium);
+  font-weight: bold;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.notice-manage-description {
+  font-size: var(--font-small);
+  color: var(--color-dark-gray);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notice-manage-date {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: var(--font-small);
+  color: var(--color-dark-gray);
+}
+
+.notice-manage-date > .material-symbols-rounded {
+  font-size: 20px;
+}
+
+@media screen and (max-width: 600px) {
+  .notice-manage-image {
+    height: 180px;
+  }
+
+  .notice-manage-content {
+    gap: var(--space-xsmall);
+  }
+}

--- a/src/components/admin/notice-management/NoticeManagementItem.js
+++ b/src/components/admin/notice-management/NoticeManagementItem.js
@@ -1,0 +1,14 @@
+import { RenderAdminNoticeItem } from '../../common/notice/AdminNoticeItem';
+import './NoticeManagementItem.css';
+
+export const RenderAdminNoticeManagementItem = post => {
+  return RenderAdminNoticeItem({
+    post,
+    itemContainerClassName: 'notice-manage-item',
+    imageClassName: 'notice-manage-image',
+    contentContainerClassName: 'notice-manage-content',
+    contentTitleClassName: 'notice-manage-title',
+    contentDescriptionClassName: 'notice-manage-description',
+    contentDateClassName: 'notice-manage-date',
+  });
+};

--- a/src/components/admin/notice-management/NoticeManagementList.css
+++ b/src/components/admin/notice-management/NoticeManagementList.css
@@ -1,0 +1,47 @@
+.admin-notice-manage-list {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  width: 100%;
+  height: 700px;
+  padding: var(--space-medium);
+  border-radius: var(--base-border-radius);
+  background-color: var(--color-pale-gray);
+  overflow-y: auto;
+}
+
+.admin-notice-manage-container {
+  width: 100%;
+  height: 300px;
+  border: 1.5px solid var(--color-dark-gray);
+  border-radius: var(--base-border-radius);
+  background-color: var(--color-white);
+  cursor: pointer;
+}
+
+.admin-notice-manage-container:hover {
+  box-shadow: var(--box-shadow-large);
+  transition: box-shadow 0.3s;
+}
+
+@media screen and (max-width: 1200px) {
+  .admin-notice-manage-list {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media screen and (max-width: 900px) {
+  .admin-notice-manage-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .admin-notice-manage-list {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-notice-manage-container {
+    height: 250px;
+  }
+}

--- a/src/components/admin/notice-management/NoticeManagementList.css
+++ b/src/components/admin/notice-management/NoticeManagementList.css
@@ -24,6 +24,34 @@
   transition: box-shadow 0.3s;
 }
 
+.admin-notice-manage-empty {
+  width: 100%;
+  height: 100%;
+  min-height: 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: var(--font-size-large);
+  color: var(--color-dark-gray);
+  animation: bounce 2s ease-in-out infinite;
+}
+
+.admin-notice-manage-list li.admin-notice-manage-empty {
+  width: 100%;
+  height: 100%;
+  grid-column: 1 / -1;
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-15px);
+  }
+}
+
 @media screen and (max-width: 1200px) {
   .admin-notice-manage-list {
     grid-template-columns: repeat(3, 1fr);

--- a/src/components/admin/notice-management/NoticeManagementList.js
+++ b/src/components/admin/notice-management/NoticeManagementList.js
@@ -1,0 +1,13 @@
+import { RenderAdminNoticeList } from '../../common/notice/AdminNoticeList';
+import { RenderAdminNoticeManagementItem } from './NoticeManagementItem';
+import './NoticeManagementList.css';
+
+export const RenderAdminNoticeManagementList = async container => {
+  await RenderAdminNoticeList({
+    container,
+    renderItemComponent: RenderAdminNoticeManagementItem,
+    containerClassName: 'admin-notice-manage-list',
+    itemClassName: 'admin-notice-manage-container',
+    itemIdPrefix: 'admin-notice-manage',
+  });
+};

--- a/src/components/admin/notice-management/NoticeManagementList.js
+++ b/src/components/admin/notice-management/NoticeManagementList.js
@@ -2,12 +2,16 @@ import { RenderAdminNoticeList } from '../../common/notice/AdminNoticeList';
 import { RenderAdminNoticeManagementItem } from './NoticeManagementItem';
 import './NoticeManagementList.css';
 
-export const RenderAdminNoticeManagementList = async container => {
+export const RenderAdminNoticeManagementList = async (
+  container,
+  onDataLoad,
+) => {
   await RenderAdminNoticeList({
     container,
     renderItemComponent: RenderAdminNoticeManagementItem,
     containerClassName: 'admin-notice-manage-list',
     itemClassName: 'admin-notice-manage-container',
     itemIdPrefix: 'admin-notice-manage',
+    onDataLoad,
   });
 };

--- a/src/components/admin/notice-management/NoticeManagementList.js
+++ b/src/components/admin/notice-management/NoticeManagementList.js
@@ -13,6 +13,7 @@ export const RenderAdminNoticeManagementList = async (
     containerClassName: 'admin-notice-manage-list',
     itemClassName: 'admin-notice-manage-container',
     itemIdPrefix: 'admin-notice-manage',
+    emptyClassName: 'admin-notice-manage-empty',
     onDataLoad,
     searchInput,
   });

--- a/src/components/admin/notice-management/NoticeManagementList.js
+++ b/src/components/admin/notice-management/NoticeManagementList.js
@@ -5,6 +5,7 @@ import './NoticeManagementList.css';
 export const RenderAdminNoticeManagementList = async (
   container,
   onDataLoad,
+  searchInput = '',
 ) => {
   await RenderAdminNoticeList({
     container,
@@ -13,5 +14,6 @@ export const RenderAdminNoticeManagementList = async (
     itemClassName: 'admin-notice-manage-container',
     itemIdPrefix: 'admin-notice-manage',
     onDataLoad,
+    searchInput,
   });
 };

--- a/src/components/common/notice/AdminNoticeItem.js
+++ b/src/components/common/notice/AdminNoticeItem.js
@@ -1,0 +1,27 @@
+export const RenderAdminNoticeItem = ({
+  post,
+  itemContainerClassName,
+  imageClassName,
+  contentContainerClassName,
+  contentTitleClassName,
+  contentDescriptionClassName,
+  contentDateClassName,
+}) => {
+  return `
+        <div class="${itemContainerClassName}">
+          <div class="${imageClassName}">
+            <img src="${post.post_image}" alt="${post.post_title}" />
+          </div>
+          <div class="${contentContainerClassName}">
+            <div class="${contentTitleClassName}">${post.post_title}</div>
+            <div class="${contentDescriptionClassName}">${post.post_description}</div>
+            <div class="${contentDateClassName}">
+              <span class="material-symbols-rounded">
+                  update
+              </span>
+              <p>${new Date(post.updated_at).toLocaleString()}</p>
+            </div>
+          </div>
+        </div>
+      `;
+};

--- a/src/components/common/notice/AdminNoticeList.js
+++ b/src/components/common/notice/AdminNoticeList.js
@@ -6,6 +6,7 @@ export const RenderAdminNoticeList = async ({
   containerClassName,
   itemClassName,
   itemIdPrefix,
+  onDataLoad,
 }) => {
   try {
     const response = await axios.get(
@@ -14,6 +15,11 @@ export const RenderAdminNoticeList = async ({
     const posts = response.data.sort(
       (a, b) => new Date(b.updated_at) - new Date(a.updated_at),
     );
+
+    // 데이터 로드 후 총 개수를 상위 컴포넌트로 전달
+    if (onDataLoad) {
+      onDataLoad(posts.length);
+    }
 
     container.innerHTML = `
       <ul class="${containerClassName}">

--- a/src/components/common/notice/AdminNoticeList.js
+++ b/src/components/common/notice/AdminNoticeList.js
@@ -7,14 +7,25 @@ export const RenderAdminNoticeList = async ({
   itemClassName,
   itemIdPrefix,
   onDataLoad,
+  searchInput = '',
 }) => {
   try {
     const response = await axios.get(
       '../../../../server/data/company_posts.json',
     );
-    const posts = response.data.sort(
+    let posts = response.data.sort(
       (a, b) => new Date(b.updated_at) - new Date(a.updated_at),
     );
+
+    // 검색어가 입력되었을 때 필터링
+    if (searchInput.trim() !== '') {
+      const searchResult = searchInput.toLowerCase();
+      posts = posts.filter(
+        post =>
+          post.post_title.toLowerCase().includes(searchResult) ||
+          post.post_description.toLowerCase().includes(searchResult),
+      );
+    }
 
     // 데이터 로드 후 총 개수를 상위 컴포넌트로 전달
     if (onDataLoad) {

--- a/src/components/common/notice/AdminNoticeList.js
+++ b/src/components/common/notice/AdminNoticeList.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+export const RenderAdminNoticeList = async ({
+  container,
+  renderItemComponent,
+  containerClassName,
+  itemClassName,
+  itemIdPrefix,
+}) => {
+  try {
+    const response = await axios.get(
+      '../../../../server/data/company_posts.json',
+    );
+    const posts = response.data.sort(
+      (a, b) => new Date(b.updated_at) - new Date(a.updated_at),
+    );
+
+    container.innerHTML = `
+      <ul class="${containerClassName}">
+        ${posts
+          .map(
+            post => `
+            <li class="${itemClassName}" id="${itemIdPrefix}-${post.post_id}">
+              ${renderItemComponent(post)}
+            </li>
+            `,
+          )
+          .join('')}
+      </ul>
+    `;
+  } catch (e) {
+    console.error('공지를 가져오는 과정에서 에러가 발생했습니다: ', e);
+  }
+};

--- a/src/components/common/notice/AdminNoticeList.js
+++ b/src/components/common/notice/AdminNoticeList.js
@@ -6,6 +6,7 @@ export const RenderAdminNoticeList = async ({
   containerClassName,
   itemClassName,
   itemIdPrefix,
+  emptyClassName,
   onDataLoad,
   searchInput = '',
 }) => {
@@ -34,15 +35,19 @@ export const RenderAdminNoticeList = async ({
 
     container.innerHTML = `
       <ul class="${containerClassName}">
-        ${posts
-          .map(
-            post => `
+        ${
+          posts.length
+            ? posts
+                .map(
+                  post => `
             <li class="${itemClassName}" id="${itemIdPrefix}-${post.post_id}">
               ${renderItemComponent(post)}
             </li>
             `,
-          )
-          .join('')}
+                )
+                .join('')
+            : `<li class="${emptyClassName}">공지사항이 없습니다.</li>`
+        }
       </ul>
     `;
   } catch (e) {

--- a/src/pages/admin/notice/notice-management/NoticeManagement.css
+++ b/src/pages/admin/notice/notice-management/NoticeManagement.css
@@ -1,0 +1,6 @@
+.admin-vacation-management-container {
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xsmall);
+}

--- a/src/pages/admin/notice/notice-management/NoticeManagement.js
+++ b/src/pages/admin/notice/notice-management/NoticeManagement.js
@@ -1,5 +1,23 @@
+import { RenderAdminNoticeManagementHeader } from '../../../../components/admin/notice-management/NoticeManagementHeader';
+import { RenderAdminNoticeManagementList } from '../../../../components/admin/notice-management/NoticeManagementList';
+
+import './NoticeManagement.css';
+
 export const RenderAdminNoticeManagement = container => {
   container.innerHTML = `
-    <div>이 곳은 관리자 공지 목록 페이지입니다.</div>
+    <main class="admin-notice-management-container">
+      <div id="adminNoticeManagementHeaderSection"></div>
+      <div id="adminNoticeManagementListSection"></div>
+    </main>
   `;
+
+  const headerSection = document.querySelector(
+    '#adminNoticeManagementHeaderSection',
+  );
+  const noticeListSection = document.querySelector(
+    '#adminNoticeManagementListSection',
+  );
+
+  RenderAdminNoticeManagementHeader(headerSection);
+  RenderAdminNoticeManagementList(noticeListSection);
 };

--- a/src/pages/admin/notice/notice-management/NoticeManagement.js
+++ b/src/pages/admin/notice/notice-management/NoticeManagement.js
@@ -12,11 +12,6 @@ export const RenderAdminNoticeManagement = container => {
     </main>
   `;
 
-  const updateTotalCount = count => {
-    const titleContainer = document.querySelector('#adminNoticeTitleContainer');
-    RenderTitle(titleContainer, `공지사항 (${count}개)`);
-  };
-
   const headerSection = document.querySelector(
     '#adminNoticeManagementHeaderSection',
   );
@@ -24,6 +19,21 @@ export const RenderAdminNoticeManagement = container => {
     '#adminNoticeManagementListSection',
   );
 
-  RenderAdminNoticeManagementHeader(headerSection);
+  // 공지사항 개수를 업데이트
+  const updateTotalCount = count => {
+    const titleContainer = document.querySelector('#adminNoticeTitleContainer');
+    RenderTitle(titleContainer, `공지사항 (${count}개)`);
+  };
+
+  // 검색어 입력 시 공지사항 목록을 필터링
+  const handleSearch = searchInput => {
+    RenderAdminNoticeManagementList(
+      noticeListSection,
+      updateTotalCount,
+      searchInput,
+    );
+  };
+
+  RenderAdminNoticeManagementHeader(headerSection, handleSearch);
   RenderAdminNoticeManagementList(noticeListSection, updateTotalCount);
 };

--- a/src/pages/admin/notice/notice-management/NoticeManagement.js
+++ b/src/pages/admin/notice/notice-management/NoticeManagement.js
@@ -1,5 +1,6 @@
 import { RenderAdminNoticeManagementHeader } from '../../../../components/admin/notice-management/NoticeManagementHeader';
 import { RenderAdminNoticeManagementList } from '../../../../components/admin/notice-management/NoticeManagementList';
+import { RenderTitle } from '../../../../components/common/title/Title';
 
 import './NoticeManagement.css';
 
@@ -11,6 +12,11 @@ export const RenderAdminNoticeManagement = container => {
     </main>
   `;
 
+  const updateTotalCount = count => {
+    const titleContainer = document.querySelector('#adminNoticeTitleContainer');
+    RenderTitle(titleContainer, `공지사항 (${count}개)`);
+  };
+
   const headerSection = document.querySelector(
     '#adminNoticeManagementHeaderSection',
   );
@@ -19,5 +25,5 @@ export const RenderAdminNoticeManagement = container => {
   );
 
   RenderAdminNoticeManagementHeader(headerSection);
-  RenderAdminNoticeManagementList(noticeListSection);
+  RenderAdminNoticeManagementList(noticeListSection, updateTotalCount);
 };

--- a/src/pages/admin/vacation-management/VacationManagement.css
+++ b/src/pages/admin/vacation-management/VacationManagement.css
@@ -2,5 +2,5 @@
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: var(--space-xsmall);
 }

--- a/src/pages/admin/vacation-management/VacationManagement.js
+++ b/src/pages/admin/vacation-management/VacationManagement.js
@@ -1,5 +1,6 @@
 import { RenderAdminVacationManagementHeader } from '../../../components/admin/vacation-management/VacationHeader';
 import { RenderAdminVacationManagementList } from '../../../components/admin/vacation-management/VacationList';
+import './VacationManagement.css';
 
 export const RenderAdminVacationManagement = container => {
   container.innerHTML = `

--- a/src/routes/Router.js
+++ b/src/routes/Router.js
@@ -14,6 +14,7 @@ import {
   RenderLogIn,
   RenderAdminVacationManagement,
   RenderUserWorkDetail,
+  RenderAdminNoticeManagement,
 } from '../pages';
 import {
   ADMIN_PATH,
@@ -145,6 +146,8 @@ export default function Router() {
     RenderAdminMemberManagement(contentEl);
   } else if (path === ADMIN_PATH.VACATION) {
     RenderAdminVacationManagement(contentEl);
+  } else if (path === ADMIN_PATH.NOTICE) {
+    RenderAdminNoticeManagement(contentEl);
   } else if (path === USER_PATH.HOME) {
     RenderUserHome(contentEl);
   } else if (path === USER_PATH.NOTICE) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,6 +3,7 @@ export const ADMIN_PATH = {
   MEMBER: '/admin/member',
   VACATION: '/admin/vacation',
   NOTICE: '/admin/notice',
+  NOTICE_UPLOAD: '/admin/notice/upload',
 };
 
 export const ADMIN_TITLE = {


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #59 

## 📝 Task Details

- 사용자 공지 목록 컴포넌트를 사용하여 퍼블리싱합니다.
- 우측 상단에는 업로드 버튼을 둡니다. 버튼 클릭 시 업로드 페이지로 라우팅되도록만 설정(아직 업로드 페이지가 없기 때문)
- 메인페이지에서의 공지 목록과 공지 관리 페이지에서의 공지의 모양을 그대로 가져와 스타일만 다르게하기 위해서 `AdminNoticeItem`과 `AdminNoticeList`안에 공통 부분을 컴포넌트화 하여 스타일만 바꿔 사용할 수 있도록 하였습니다.
- `input`에 제목과 설명에 따라 일치한다면 그 공지사항이 렌더링됩니다.
- 왼쪽 상단 `title`부분에는 `post`의 개수에 따라 총 공지사항 개수가 몇 개인지 렌더링됩니다.
- 공지사항이 없을 경우 메시지를 표시합니다.

## 📂 References

https://github.com/user-attachments/assets/d63e4e5e-336a-4266-a1d9-e45cf54b31db

## 💖 Review Requirements

### 고민했던 점

- 메인페이지에서 했던 공지사항 코드를 긁어와 사용하려다 보니까 너무 겹치고 비효율적이라고 느껴 공통적인 코드는 `common` 폴더에 넣고 스타일만 다르게 제작하여 공통적인 컴포넌트를 제작해야겠다고 생각했습니다.
- 관리 페이지에서 `페이지네이션`이 필요한지에 대해서도 고민을 해봤습니다. 관리자라면 최신 공지사항 수정여부를 판단해서 위쪽 게시글만 볼 것이라 생각했는데, 한편으로는 오래된 게시글을 삭제하기 위해서는 오래 스크롤을 내려 찾아야만 한다는 번거로움이 생깁니다. 이에 따라 추후 페이지네이션을 구현해봐야겠습니다.
