### PR TITLE
[FEAT] 관리자 공지 상세 페이지를 퍼블리싱합니다.

### DIFF
--- a/src/components/admin/home/notice/Notice.js
+++ b/src/components/admin/home/notice/Notice.js
@@ -1,30 +1,14 @@
-import axios from 'axios';
-import { RenderNoticeItem } from '../../../common/notice/NoticeItem';
+import { RenderNoticeItem } from './NoticeItem';
+import { RenderAdminNoticeList } from '../../../common/notice/AdminNoticeList';
 import './Notice.css';
 
 export const RenderAdminHomeNotice = async container => {
-  try {
-    const response = await axios.get(
-      '../../../../../server/data/company_posts.json',
-    );
-    const posts = response.data.sort(
-      (a, b) => new Date(b.updated_at) - new Date(a.updated_at),
-    );
-
-    container.innerHTML = `
-          <ul class="admin-notice-list">
-            ${posts
-              .map(
-                post => `
-                <li class="admin-notice-container" id="admin-notice-${post.post_id}">
-                  ${RenderNoticeItem(null, post)}
-                </li>
-                `,
-              )
-              .join('')}
-          </ul>
-        `;
-  } catch (e) {
-    console.error('공지를 가져오는 과정에서 에러가 발생했습니다: ', e);
-  }
+  await RenderAdminNoticeList({
+    container,
+    renderItemComponent: RenderNoticeItem,
+    containerClassName: 'admin-notice-list',
+    itemClassName: 'admin-notice-container',
+    itemIdPrefix: 'admin-notice',
+    emptyClassName: 'admin-notice-empty',
+  });
 };

--- a/src/components/admin/home/notice/NoticeItem.css
+++ b/src/components/admin/home/notice/NoticeItem.css
@@ -1,0 +1,48 @@
+.notice-item {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.notice-image {
+  width: 100%;
+  height: 200px;
+}
+
+.notice-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.notice-content {
+  padding: var(--space-small);
+  flex: 1;
+}
+
+.notice-title {
+  font-size: var(--font-medium);
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notice-description {
+  font-size: var(--font-small);
+  color: var(--color-dark-gray);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notice-date {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: var(--font-small);
+  color: var(--color-dark-gray);
+}
+
+.notice-date > .material-symbols-rounded {
+  font-size: 18px;
+}

--- a/src/components/admin/notice-detail/NoticeDetailItem.css
+++ b/src/components/admin/notice-detail/NoticeDetailItem.css
@@ -1,3 +1,16 @@
+.admin-notice-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 var(--space-large);
+  margin-bottom: var(--space-medium);
+}
+
+.admin-notice-detail-button-group {
+  display: flex;
+  gap: var(--space-small);
+}
+
 .back-to-noticeList {
   cursor: pointer;
 }
@@ -45,6 +58,10 @@
 }
 
 @media (width <= 767px) {
+  .admin-notice-detail-header {
+    padding: 0 var(--space-medium);
+  }
+
   .admin-notice-detail {
     padding: 0 var(--space-medium);
   }
@@ -73,6 +90,10 @@
   .admin-notice-detail-title {
     font-size: 16px;
     text-align: center;
+  }
+
+  .admin-notice-detail-header {
+    padding: 0 var(--space-small);
   }
 
   .admin-notice-detail {

--- a/src/components/admin/notice-detail/NoticeDetailItem.css
+++ b/src/components/admin/notice-detail/NoticeDetailItem.css
@@ -1,0 +1,90 @@
+.back-to-noticeList {
+  cursor: pointer;
+}
+
+.admin-notice-detail {
+  width: 100%;
+  height: 100%;
+  padding: 0 var(--space-large);
+  text-align: center;
+}
+
+.admin-notice-detail-title {
+  font-size: 35px;
+  font-weight: 700;
+  margin-bottom: var(--space-medium);
+}
+
+.admin-notice-detail-description {
+  font-size: var(--font-large);
+  margin-bottom: var(--space-medium);
+}
+
+.admin-notice-detail img {
+  width: 100%;
+  margin: var(--space-medium) auto;
+  border-radius: var(--base-border-radius);
+}
+
+.admin-notice-detail-content {
+  line-height: 1.5;
+  white-space: pre-line;
+  margin-bottom: var(--space-large);
+}
+
+.admin-notice-detail-upload-date,
+.admin-notice-detail-edit-date {
+  text-align: right;
+  font-size: var(--font-small);
+  line-height: 1.2;
+  color: var(--color-dark-gray);
+}
+
+.admin-notice-detail .edit-date {
+  margin-bottom: var(--space-medium);
+}
+
+@media (width <= 767px) {
+  .admin-notice-detail {
+    padding: 0 var(--space-medium);
+  }
+
+  .admin-notice-detail-title {
+    font-size: var(--font-large);
+    margin-bottom: var(--space-small);
+  }
+
+  .admin-notice-detail-description {
+    font-size: var(--font-medium);
+    margin-bottom: var(--space-small);
+  }
+
+  .admin-notice-detail img {
+    margin: var(--space-small) auto;
+  }
+
+  .admin-notice-detail-content {
+    font-size: var(--font-medium);
+    margin-bottom: var(--space-medium);
+  }
+}
+
+@media (width <= 480px) {
+  .admin-notice-detail-title {
+    font-size: 16px;
+    text-align: center;
+  }
+
+  .admin-notice-detail {
+    padding: 0 var(--space-small);
+    text-align: left;
+  }
+
+  .admin-notice-detail-content {
+    font-size: var(--font-medium);
+  }
+
+  .admin-notice-detail-description {
+    text-align: center;
+  }
+}

--- a/src/components/admin/notice-detail/NoticeDetailItem.js
+++ b/src/components/admin/notice-detail/NoticeDetailItem.js
@@ -1,9 +1,26 @@
 import { ApiClient } from '../../../apis/ApiClient';
 import { RenderNotFound } from '../../../pages';
+import { ADMIN_PATH } from '../../../utils/constants';
+import { Button } from '../../ui/button/Button';
+import navigate from '../../../utils/navigation';
 import './NoticeDetailItem.css';
 
 export const RenderAdminNoticeDetailItem = async (container, postId) => {
   const NOTICE_DATA = '../../../../server/data/company_posts.json';
+
+  const modifyButton = new Button({
+    text: '수정',
+    color: 'green',
+    shape: 'block',
+    borderRadius: '14',
+  });
+
+  const deleteButton = new Button({
+    text: '삭제',
+    color: 'coral',
+    shape: 'block',
+    borderRadius: '14',
+  });
 
   try {
     const response = await ApiClient.get(NOTICE_DATA);
@@ -16,7 +33,10 @@ export const RenderAdminNoticeDetailItem = async (container, postId) => {
     }
 
     container.innerHTML = `
-        <span class="material-symbols-rounded back-to-noticeList">arrow_left_alt</span> 
+        <div class="admin-notice-detail-header">
+          <span class="material-symbols-rounded back-to-noticeList">arrow_left_alt</span>
+          <div class="admin-notice-detail-button-group"></div>
+        </div>
         <div class="admin-notice-detail">
             <h1 class="admin-notice-detail-title">${post.post_title}</h1>
             <h3 class="admin-notice-detail-description">${post.post_description}</h3>
@@ -26,6 +46,25 @@ export const RenderAdminNoticeDetailItem = async (container, postId) => {
             <p class="admin-notice-detail-content">${post.post_content}</p>
         </div>
         `;
+
+    const buttonGroup = document.querySelector(
+      '.admin-notice-detail-button-group',
+    );
+    buttonGroup.appendChild(modifyButton);
+    buttonGroup.appendChild(deleteButton);
+    buttonGroup.addEventListener('click', e => {
+      if (e.target.textContent === '수정') {
+        navigate(`${ADMIN_PATH.NOTICE}/${postId}/edit`);
+      } else if (e.target.textContent === '삭제') {
+        // 추후 모달로 변경
+        const isDelete = confirm('정말 삭제하시겠습니까?');
+
+        if (isDelete) {
+          alert('삭제되었습니다.');
+          navigate(ADMIN_PATH.NOTICE);
+        }
+      }
+    });
 
     //뒤로가기
     document

--- a/src/components/admin/notice-detail/NoticeDetailItem.js
+++ b/src/components/admin/notice-detail/NoticeDetailItem.js
@@ -1,0 +1,39 @@
+import { ApiClient } from '../../../apis/ApiClient';
+import { RenderNotFound } from '../../../pages';
+import './NoticeDetailItem.css';
+
+export const RenderAdminNoticeDetailItem = async (container, postId) => {
+  const NOTICE_DATA = '../../../../server/data/company_posts.json';
+
+  try {
+    const response = await ApiClient.get(NOTICE_DATA);
+    const posts = response.data;
+
+    const post = posts.find(post => post.post_id === postId);
+
+    if (!post) {
+      RenderNotFound(container);
+    }
+
+    container.innerHTML = `
+        <span class="material-symbols-rounded back-to-noticeList">arrow_left_alt</span> 
+        <div class="admin-notice-detail">
+            <h1 class="admin-notice-detail-title">${post.post_title}</h1>
+            <h3 class="admin-notice-detail-description">${post.post_description}</h3>
+            <p class="admin-notice-detail-upload-date">게시일: ${new Date(post.created_at).toLocaleDateString()}</p>
+            <p class="admin-notice-detail-edit-date">수정일: ${new Date(post.updated_at).toLocaleDateString()}</p>
+            <img src="${post.post_image}" alt="${post.post_title}" />
+            <p class="admin-notice-detail-content">${post.post_content}</p>
+        </div>
+        `;
+
+    //뒤로가기
+    document
+      .querySelector('.back-to-noticeList')
+      .addEventListener('click', () => {
+        history.back();
+      });
+  } catch (e) {
+    console.error('공지를 가져오는 과정에서 에러가 발생했습니다:', e);
+  }
+};

--- a/src/components/common/notice/AdminNoticeItem.js
+++ b/src/components/common/notice/AdminNoticeItem.js
@@ -1,3 +1,6 @@
+import { ADMIN_PATH } from '../../../utils/constants';
+import navigate from '../../../utils/navigation';
+
 export const RenderAdminNoticeItem = ({
   post,
   itemContainerClassName,
@@ -7,8 +10,26 @@ export const RenderAdminNoticeItem = ({
   contentDescriptionClassName,
   contentDateClassName,
 }) => {
+  const handleNoticeClick = () => {
+    navigate(`${ADMIN_PATH.NOTICE}/${post.post_id}`);
+  };
+
+  const uniqueId = `admin-notice-item-${post.post_id}`;
+
+  // DOM이 실제로 생성되고 난 후에 이벤트 리스너를 등록하기 위해 setTimeout을 사용함.
+  // HTML 문자열을 반환하고 있는데 이는 나중에 DOM에 등록되고
+  // document.getElementById를 바로 실행하면 HTML이 아직 DOM에 등록되지 않아 null이 반환될 수 있기 때문.
+  // setTimeout을 사용하면 해당 함수가 이벤트 루프에 등록되어 나중에 실행되기 때문에 DOM이 생성된 후에 실행됨.
+  // setTimeout은 콜백을 매크로태스크 큐에 넣고, 현재 실행 코드 스택이 비워지고 DOM 업데이트가 이뤄진 후에 실행됨.
+  setTimeout(() => {
+    const element = document.getElementById(uniqueId);
+    if (element) {
+      element.addEventListener('click', handleNoticeClick);
+    }
+  }, 0);
+
   return `
-        <div class="${itemContainerClassName}">
+        <div class="${itemContainerClassName}" id="${uniqueId}">
           <div class="${imageClassName}">
             <img src="${post.post_image}" alt="${post.post_title}" />
           </div>

--- a/src/pages/admin/notice/notice-detail/NoticeDetail.js
+++ b/src/pages/admin/notice/notice-detail/NoticeDetail.js
@@ -1,0 +1,12 @@
+import { RenderAdminNoticeDetailItem } from '../../../../components/admin/notice-detail/NoticeDetailItem';
+
+export const RenderAdminNoticeDetail = (container, noticeId) => {
+  container.innerHTML = `
+      <div class="notice-detail-container"></div>
+    `;
+
+  const noticeDetailContainer = container.querySelector(
+    '.notice-detail-container',
+  );
+  RenderAdminNoticeDetailItem(noticeDetailContainer, noticeId);
+};

--- a/src/routes/Router.js
+++ b/src/routes/Router.js
@@ -31,6 +31,7 @@ import {
 
 import { getIsMobile } from '../utils/responsive';
 import { getItem } from '../utils/storage';
+import { RenderAdminNoticeDetail } from '../pages/admin/notice/notice-detail/NoticeDetail';
 
 export default function Router() {
   const path = window.location.pathname;
@@ -141,12 +142,19 @@ export default function Router() {
 
   //postId 추출
   const paramsFormNotice = extractParams(`${USER_PATH.NOTICE}/:postId`, path);
+  const paramsFormAdminNotice = extractParams(
+    `${ADMIN_PATH.NOTICE}/:noticeId`,
+    path,
+  );
   //memberId 추출
   const paramsFormMember = extractParams(
     `${ADMIN_PATH.MEMBER}/:memberId`,
     path,
   );
   const postId = paramsFormNotice ? paramsFormNotice.postId : null;
+  const noticeId = paramsFormAdminNotice
+    ? paramsFormAdminNotice.noticeId
+    : null;
   const memberId = paramsFormMember ? paramsFormMember.memberId : null;
 
   if (path === ADMIN_PATH.HOME) {
@@ -155,6 +163,8 @@ export default function Router() {
     RenderAdminMemberManagement(contentEl);
   } else if (path === ADMIN_PATH.MEMBER_UPLOAD) {
     RenderAdminUploadMember(contentEl);
+  } else if (noticeId) {
+    RenderAdminNoticeDetail(contentEl, noticeId);
   } else if (memberId && memberId !== 'upload') {
     // postId가 있는 경우(동적 경로가 매칭된 경우)
     RenderAdminMemberDetail(contentEl, memberId);


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #65 

## 📝 Task Details

- 사용자 공지 상세 페이지와 동일한 형태입니다.
- 우측 상단에 `삭제`와 `수정` 버튼을 추가합니다.
- 공지 관리 페이지에서 공지 클릭 시 상세 페이지로 이동합니다.
- 메인 페이지에서 공지 클릭 시 상세 페이지로 이동합니다.
- `삭제` 버튼 클릭 시 임의로 `alert`가 뜨도록 하였습니다.
- 반응형 디자인까지 하였습니다.

## 📂 References

https://github.com/user-attachments/assets/db2299c8-d60e-414f-8d51-7b167d33f761

## 💖 Review Requirements

### ❇️ 트러블 슈팅

```
import { ADMIN_PATH } from '../../../utils/constants';
import navigate from '../../../utils/navigation';

export const RenderAdminNoticeItem = ({
  post,
  itemContainerClassName,
  imageClassName,
  contentContainerClassName,
  contentTitleClassName,
  contentDescriptionClassName,
  contentDateClassName,
}) => {
  const handleNoticeClick = () => {
    navigate(`${ADMIN_PATH.NOTICE}/${post.post_id}`);
  };

  const uniqueId = `admin-notice-item-${post.post_id}`;

  const element = document.getElementById(uniqueId);
  if (element) {
    element.addEventListener('click', handleNoticeClick);
  }

  return `
        <div class="${itemContainerClassName}" id="${uniqueId}">
          <div class="${imageClassName}">
            <img src="${post.post_image}" alt="${post.post_title}" />
          </div>
          <div class="${contentContainerClassName}">
            <div class="${contentTitleClassName}">${post.post_title}</div>
            <div class="${contentDescriptionClassName}">${post.post_description}</div>
            <div class="${contentDateClassName}">
              <span class="material-symbols-rounded">
                  update
              </span>
              <p>${new Date(post.updated_at).toLocaleString()}</p>
            </div>
          </div>
        </div>
      `;
};
```
위 코드는 관리자 페이지에서 `메인페이지`와 `공지 관리`페이지에서 재사용하기 위해 만든 컴포넌트였다. 그래서 클릭 시 네비게이팅 처리는 여기서만 해주면 됐다. 그러나 마주한 문제가 있었다.

```
const element = document.getElementById(uniqueId);
  if (element) {
    element.addEventListener('click', handleNoticeClick);
  }
```
위 코드와 같이 실행을 했더니 네비게이팅 되지 않는 문제를 마주했다. 왜 그런지 만들었던 파일을 다시 한 번 살펴보며 문제를 파악했다. 하지만 좀처럼 파악되지 않아 찾아보았다.

문제는 바로 위 코드였다. 

현재 코드의 실행 순서를 보면
1. `RenderAdminNoticeItem` 함수가 HTML 문자열을 반환하고 있다.
2. 이 HTML 문자열이 나중에 DOM에 삽입된다.
3. `document.getElementById()`를 바로 실행하면, HTML이 아직 DOM에 삽입되기 전이라 요소를 찾지 못할 수 있다.

위와 같은 실행 순서 때문에 네비게이팅 처리가 되지 않았던 것이다.

이를 다음과 같이 바꾸면 해결 됐다.

```
setTimeout(() => {
    const element = document.getElementById(uniqueId);
    if (element) {
      element.addEventListener('click', handleNoticeClick);
    }
  }, 0);
```
변경된 코드를 보면 주석에도 적어놨듯 `setTimeout`을 사용하였다. 심지어 `0ms` 딜레이이다.
이를 사용하면
1. 현재 실행 중인 JavaScript 코드가 완료될 때까지 기다린다.
2. 브라우저가 DOM을 업데이트할 시간을 갖는다.
3. 그 후 이벤트 리스너를 추가하는 코드가 실행된다.

이는 JavaScript의 이벤트 루프와 관련이 있다고 한다. `setTimeout`은 콜백을 매크로태스크 큐에 넣어서 현재 실행 중인 코드 스택이 비워지고 DOM 업데이트가 이루어진 후에 실행되도록 보장하기 때문이다.

`setTimeout`이 없이 실행하면 바로 `getElementById`가 실행되어, DOM이 아직 업데이트 되기 전이라 `null`을 반환할 수 있는 가능성이 있으며 결과적으로 이벤트 리스너가 추가되지 않는 것이었다.
