### PR TITLE
[FEAT] 관리자 공지관리와 휴가/공가 관리 페이지에서 페이지네이션을 구현합니다.

### DIFF
--- a/src/components/admin/notice-management/NoticeManagementList.css
+++ b/src/components/admin/notice-management/NoticeManagementList.css
@@ -3,8 +3,8 @@
   grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
   width: 100%;
-  height: 700px;
-  padding: var(--space-medium);
+  height: auto;
+  padding: var(--space-large) var(--space-medium);
   border-radius: var(--base-border-radius);
   background-color: var(--color-pale-gray);
   overflow-y: auto;

--- a/src/components/admin/notice-management/NoticeManagementList.js
+++ b/src/components/admin/notice-management/NoticeManagementList.js
@@ -6,6 +6,7 @@ export const RenderAdminNoticeManagementList = async (
   container,
   onDataLoad,
   searchInput = '',
+  currentPage = 1,
 ) => {
   await RenderAdminNoticeList({
     container,
@@ -16,5 +17,8 @@ export const RenderAdminNoticeManagementList = async (
     emptyClassName: 'admin-notice-manage-empty',
     onDataLoad,
     searchInput,
+    usePagination: true,
+    itemsPerPage: 8,
+    currentPage,
   });
 };

--- a/src/components/admin/vacation-management/VacationList.css
+++ b/src/components/admin/vacation-management/VacationList.css
@@ -7,7 +7,7 @@
 .admin-vacation-list {
   border-radius: 10px;
   overflow-y: auto;
-  max-height: 700px;
+  height: auto;
 }
 
 .admin-vacation-status-dot {

--- a/src/components/admin/vacation-management/VacationList.js
+++ b/src/components/admin/vacation-management/VacationList.js
@@ -3,11 +3,13 @@ import axios from 'axios';
 import { Accordion } from '../../ui/accordion/Accordion';
 import { Button } from '../../ui/button/Button';
 import { sortByName } from '../../../utils/sortByName';
+import { Pagenation } from '../../common/pagenation/Pagenation';
 import './VacationList.css';
 
 export const RenderAdminVacationManagementList = async (
   container,
   filter = { type: 'vacation-all', status: 'approved-all' },
+  currentPage = 1,
 ) => {
   container.innerHTML = `<div class="loading">휴가 정보를 가져오는 중입니다.</div>`;
 
@@ -171,18 +173,43 @@ export const RenderAdminVacationManagementList = async (
       </article>
     `;
 
+    const itemsPerPage = 6;
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    const diplayedAbsencesList = sortedAbsenceUsersData.slice(
+      startIndex,
+      endIndex,
+    );
+
     // 아코디언 렌더링
     container.innerHTML = `
       <section class="admin-vacation-list-section">
         <div class="admin-vacation-list">
             ${Accordion({
-              items: sortedAbsenceUsersData,
+              items: diplayedAbsencesList,
               renderHeader,
               renderContent,
             })}
         </div>
       </section>
     `;
+
+    const paginationContainer = document.createElement('div');
+    paginationContainer.className = 'pagination';
+
+    const handlePageChange = newPage => {
+      RenderAdminVacationManagementList(container, filter, newPage);
+    };
+
+    const paginationElement = Pagenation(
+      sortedAbsenceUsersData.length,
+      itemsPerPage,
+      currentPage,
+      handlePageChange,
+    );
+
+    paginationContainer.appendChild(paginationElement);
+    container.appendChild(paginationContainer);
   } catch (error) {
     let errorMessage = '데이터를 불러오는 중 오류가 발생했습니다.';
 

--- a/src/components/common/pagenation/Pagenation.css
+++ b/src/components/common/pagenation/Pagenation.css
@@ -14,6 +14,6 @@
 }
 
 .pagination-btn.active {
-  color: var(--color-blue);
-  border: none;
+  background-color: var(--color-blue);
+  color: black;
 }

--- a/src/pages/admin/notice/notice-management/NoticeManagement.js
+++ b/src/pages/admin/notice/notice-management/NoticeManagement.js
@@ -31,9 +31,10 @@ export const RenderAdminNoticeManagement = container => {
       noticeListSection,
       updateTotalCount,
       searchInput,
+      1,
     );
   };
 
   RenderAdminNoticeManagementHeader(headerSection, handleSearch);
-  RenderAdminNoticeManagementList(noticeListSection, updateTotalCount);
+  RenderAdminNoticeManagementList(noticeListSection, updateTotalCount, '', 1);
 };


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #90 

## 📝 Task Details

- 관리자 공지관리 페이지에서 한 페이지에 `8`개의 공지사항이 나오도록 페이지네이션을 설정해요.
- 관리자 휴가/공가 페이지에서 한 페이지에 `6`개의 휴가/공가 사항이 나오도록 설정해요.
- 페이지네이션의 버튼 활성화 시 css를 일부 수정했어요.

## 📂 References

https://github.com/user-attachments/assets/21d1a670-d5a3-4e71-9043-a4d7c639db92

## 💖 Review Requirements

- 리뷰 요구사항을 적어주세요!
